### PR TITLE
doc(.github): fix template

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug.yml
@@ -2,7 +2,6 @@
 name: "🐛 Bug Report"
 description: Report a bug
 title: "package: short issue description"
-type: [bug]
 
 body:
   - type: markdown


### PR DESCRIPTION
Fix this error:

> type must be of type String and cannot be empty. [Learn more about this error.](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string)