### PR TITLE
fix: Exit process if gcloud is not found

### DIFF
--- a/packages/gcloud-mcp/src/index.test.ts
+++ b/packages/gcloud-mcp/src/index.test.ts
@@ -52,14 +52,20 @@ test('should initialize Gemini CLI when --gemini-cli-init is provided', async ()
   expect(initializeGeminiCLI).toHaveBeenCalled();
 });
 
-test('should log a message if gcloud is not available', async () => {
+test('should exit if gcloud is not available', async () => {
   process.argv = ['node', 'index.js'];
   vi.spyOn(gcloud, 'isAvailable').mockResolvedValue(false);
-  const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.stubGlobal('process', { ...process, exit: vi.fn() });
+
   await import('./index.js');
+
   expect(gcloud.isAvailable).toHaveBeenCalled();
-  expect(consoleLogSpy).toHaveBeenCalledWith('Unable to start gcloud mcp server: gcloud executable not found.');
-  consoleLogSpy.mockRestore();
+  expect(consoleErrorSpy).toHaveBeenCalledWith('Unable to start gcloud mcp server: gcloud executable not found.');
+  expect(process.exit).toHaveBeenCalledWith(1);
+
+  consoleErrorSpy.mockRestore();
+  vi.unstubAllGlobals();
 });
 
 describe('with --config flag', () => {

--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -51,7 +51,8 @@ const main = async () => {
 
   const isAvailable = await gcloud.isAvailable();
   if (!isAvailable) {
-    console.log('Unable to start gcloud mcp server: gcloud executable not found.');
+    console.error('Unable to start gcloud mcp server: gcloud executable not found.');
+    process.exit(1);
   }
 
   let config: GcloudMcpConfig = {};


### PR DESCRIPTION
Updates the server startup logic to exit with a non-zero status code if the gcloud executable is not found in the system's PATH.

This prevents the server from running in a non-functional state. The corresponding test has been updated to validate this new behavior.