### PR TITLE
fix: improve error messages for better agent recovery

### DIFF
--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
@@ -71,7 +71,12 @@ describe('createRunGcloudCommand', () => {
 
       expect(gcloudInvoke).not.toHaveBeenCalled();
       expect(result).toEqual({
-        content: [{ type: 'text', text: 'Command not allowed.' }],
+        content: [
+          {
+            type: 'text',
+            text: `Command is not part of this tool's current allowlist of enabled commands.`,
+          },
+        ],
       });
     });
   });
@@ -86,7 +91,12 @@ describe('createRunGcloudCommand', () => {
 
       expect(gcloudInvoke).not.toHaveBeenCalled();
       expect(result).toEqual({
-        content: [{ type: 'text', text: 'Command denied.' }],
+        content: [
+          {
+            type: 'text',
+            text: `Command is part of this tool's current denylist of disabled commands.`,
+          },
+        ],
       });
     });
 
@@ -125,7 +135,12 @@ describe('createRunGcloudCommand', () => {
 
       expect(gcloudInvoke).not.toHaveBeenCalled();
       expect(result).toEqual({
-        content: [{ type: 'text', text: 'Command denied.' }],
+        content: [
+          {
+            type: 'text',
+            text: `Command is part of this tool's current denylist of disabled commands.`, // Corrected: Removed extra backticks and escaped internal backticks
+          },
+        ],
       });
     });
   });
@@ -176,7 +191,7 @@ describe('createRunGcloudCommand', () => {
 
       expect(gcloudInvoke).toHaveBeenCalledWith(['a', 'c']);
       expect(result).toEqual({
-        content: [{ type: 'text', text: 'An unknown error ocurred.' }],
+        content: [{ type: 'text', text: 'An unknown error occurred.' }],
         isError: true,
       });
     });

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
@@ -65,10 +65,24 @@ export const createRunGcloudCommand = (allowlist: string[] = [], denylist: strin
         const command = args.join(' ');
 
         if (!allowedCommands(allowlist).contains(command)) {
-          return { content: [{ type: 'text', text: 'Command not allowed.' }] };
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Command is not part of this tool's current allowlist of enabled commands.`,
+              },
+            ],
+          };
         }
         if (deniedCommands(denylist).contains(command)) {
-          return { content: [{ type: 'text', text: 'Command denied.' }] };
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Command is part of this tool's current denylist of disabled commands.`,
+              },
+            ],
+          };
         }
 
         try {
@@ -84,7 +98,7 @@ export const createRunGcloudCommand = (allowlist: string[] = [], denylist: strin
           }
           return { content: [{ type: 'text', text: result }] };
         } catch (e: unknown) {
-          const msg = e instanceof Error ? e.message : 'An unknown error ocurred.';
+          const msg = e instanceof Error ? e.message : 'An unknown error occurred.';
           return { content: [{ type: 'text', text: msg }], isError: true };
         }
       },


### PR DESCRIPTION
Previous error messages didn't give enough information to the agent about why the commands were not executed. This change provides that clarification (without declaring what the agent should do to resolve the situation).