### PR TITLE
ci: add windows and macos tests

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -40,9 +40,14 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    needs: lint
     permissions:
       contents: read # For checkout
+    strategy:
+      fail-fast: false # So we can see all test failures
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Adds Windows and MacOS testing.

**Does not yet introduce multiple versions of Node to the matrix.**