### PR TITLE
feat: Add --version flag

### DIFF
--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -42,7 +42,9 @@ const main = async () => {
     .option('config', {
       type: 'string',
       description: 'Path to a JSON configuration file (must be an absolute path).',
-    }).argv;
+    })
+    .version(pkg.version)
+    .alias('version', 'v').argv;
 
   if (argv.geminiCliInit) {
     await initializeGeminiCLI();


### PR DESCRIPTION
Introduces a --version flag (with a -v alias) to the gcloud-mcp server.

When used, the application prints the current version and exits.

```
$ npm start -w gcloud-mcp -- --version
npm warn Unknown user config "always-auth" (//us-west1-npm.pkg.dev/gemini-code-dev/gemini-code/:always-auth). This will stop working in the next major version of npm.

> gcloud-mcp@0.1.0 start
> node dist/src/index.js --version

0.1.0
```