### PR TITLE
doc(.github/ISSUE_TEMPLATE): simplify bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug.yml
@@ -1,7 +1,6 @@
 ---
 name: "🐛 Bug Report"
 description: Report a bug
-title: "package: short issue description"
 
 body:
   - type: markdown


### PR DESCRIPTION
Simplify the bug report template by removing the Additional Information/Context, OS, and Server Version sections for now. 

Move the server dropdown to the top of the template, since it’s the first piece of information needed for triaging.

Leave the title field empty so users can’t accidentally submit it with the default `package: short issue description`.