### PR TITLE
fix: gcloud-mcp extension name

### DIFF
--- a/packages/gcloud-mcp/src/commands/init-gemini-cli.test.ts
+++ b/packages/gcloud-mcp/src/commands/init-gemini-cli.test.ts
@@ -49,7 +49,7 @@ test('initializeGeminiCLI should create directory and write files', async () => 
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
     contextFileName: 'GEMINI.md',
     mcpServers: {
-      gcloud: {
+      'gcloud-mcp': {
         command: 'npx',
         args: ['-y', '@google-cloud/gcloud-mcp']
       },
@@ -83,7 +83,7 @@ test('initializeGeminiCLI should create directory and write files when process.e
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
     contextFileName: 'GEMINI.md',
     mcpServers: {
-      gcloud: {
+      'gcloud-mcp': {
         command: 'npx',
         args: ['-y', '@google-cloud/gcloud-mcp']
       },

--- a/packages/gcloud-mcp/src/commands/init-gemini-cli.ts
+++ b/packages/gcloud-mcp/src/commands/init-gemini-cli.ts
@@ -39,7 +39,7 @@ export const initializeGeminiCLI = async () => {
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
     contextFileName: 'GEMINI.md',
     mcpServers: {
-      gcloud: {
+      'gcloud-mcp': {
         command: 'npx',
         args: ['-y', '@google-cloud/gcloud-mcp'],
       },


### PR DESCRIPTION
fix: gcloud-mcp extension name


```
gemini mcp list                                                                                                                                                                                                                        ─╯
Configured MCP servers:

✓ gcloud-mcp: npx -y @google-cloud/gcloud-mcp (stdio) - Connected
```