### PR TITLE
chore: delete .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./node_modules/gts/"
-}


### PR DESCRIPTION
This will ensure that we only use eslintrc.config.js, which will ensure header checking.

Unfortunately this library is using a newer eslint config which gts is not up to date with. So, we will skip importing the gts eslint config rules for now, and I'll make a TODO issue to update this config once gts' eslint is up-to-date.

see https://github.com/googleapis/gcloud-mcp/issues/64