### PR TITLE
feat: base integration test setup

### DIFF
--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: 'node:20'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        npm install
+        npm install -g
+        npm run build
+        npm install -g @google/gemini-cli
+        gcloud-mcp init --agent=gemini-cli
+        gemini mcp list
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
baseline integration test setup to:

1) install gemini cli
2) git clone gcloud-mcp (head)
3) install / build
4) init gcloud-mcp
5) gemini mcp list (extension was configured)

Example run: https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/50932f73-38b2-42b7-9c77-77ce9cbf8776?e=13802955&project=gcloud-mcp-testing -->> **can also be seen in the checks below in this PR (gcloud-mcp-testing-integration-setup)**

Actual assertions will be added in a followup to assert certain output but as of now, the test will only fail if the install / build process itself fails. A readme on how to run these manually will be added in a followup as well.
