### PR TITLE
feat: add capabilities entry

### DIFF
--- a/packages/gcloud-mcp/src/index.test.ts
+++ b/packages/gcloud-mcp/src/index.test.ts
@@ -20,6 +20,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createRunGcloudCommand } from './tools/run_gcloud_command.js';
 import * as gcloud from './gcloud.js';
 import { init } from './commands/init.js';
+import pkg from '../package.json' with { type: 'json' };
 
 vi.mock('../package.json', () => ({
   default: {
@@ -75,9 +76,9 @@ test('should start the McpServer if gcloud is available', async () => {
   expect(McpServer).toHaveBeenCalledWith(
     {
       name: 'gcloud-mcp-server',
-      version: '0.1.0',
+      version: pkg.version,
     },
-    { capabilities: { logging: {}, tools: {} } },
+    { capabilities: { tools: {} } },
   );
   expect(createRunGcloudCommand).toHaveBeenCalledWith(default_denylist);
   expect(registerToolSpy).toHaveBeenCalledWith(vi.mocked(McpServer).mock.instances[0]);

--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -52,7 +52,7 @@ const main = async () => {
           name: 'gcloud-mcp-server',
           version: pkg.version,
         },
-        { capabilities: { logging: {}, tools: {} } },
+        { capabilities: { tools: {} } },
       );
       createRunGcloudCommand(denyListSet).register(server);
       await server.connect(new StdioServerTransport());


### PR DESCRIPTION
feat: add capabilities entry


Per the MCP docs: 
`Servers that support tools MUST declare the tools capability:`

Similar for logging: https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#capabilities



BEGIN_COMMIT_OVERRIDE
feat: add capabilities entry to server metadata
END_COMMIT_OVERRIDE