### PR TITLE
feat: check gcloud available on init

### DIFF
--- a/packages/gcloud-mcp/src/commands/init.test.ts
+++ b/packages/gcloud-mcp/src/commands/init.test.ts
@@ -48,16 +48,12 @@ describe('init', () => {
       $0: 'test',
       _: [],
     };
-    await expect(init.handler(argv)).rejects.toThrow(
-      'Unknown agent: not-gemini-cli'
-    );
+    await expect(init.handler(argv)).rejects.toThrow('Unknown agent: not-gemini-cli');
     expect(initializeGeminiCLI).not.toHaveBeenCalled();
   });
 
   it('should warn if gcloud is not available', async () => {
-    const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.mocked(gcloud.isAvailable).mockResolvedValue(false);
     const argv = {
       agent: 'gemini-cli',
@@ -66,14 +62,12 @@ describe('init', () => {
     };
     await init.handler(argv);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      '⚠️❗ gcloud executable not found. The MCP server may have limited functionality.'
+      "⚠️❗ gcloud executable not found. The MCP server won't start unless gcloud is available.",
     );
   });
 
   it('should not warn if gcloud is available', async () => {
-    const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.mocked(gcloud.isAvailable).mockResolvedValue(true);
     const argv = {
       agent: 'gemini-cli',

--- a/packages/gcloud-mcp/src/commands/init.ts
+++ b/packages/gcloud-mcp/src/commands/init.ts
@@ -40,9 +40,7 @@ export const init: CommandModule<object, InstallArgs> = {
     }
     const isAvailable = await gcloud.isAvailable();
     if (!isAvailable) {
-      console.warn(
-        '⚠️❗ gcloud executable not found. The MCP server may have limited functionality.'
-      );
+      console.warn("⚠️❗ gcloud executable not found. The MCP server won't start unless gcloud is available.");
     }
   },
 };


### PR DESCRIPTION
Adding a check during init of gcloud-mcp to check for the gcloud binary and warn if not available. This is a hidden issue caught in our integration test since gemini does not surface logs, we need to warn the user of any possible issues prior to any gemini invocations.

Example for CI logs in this PR:

<img width="788" height="127" alt="Screenshot 2025-08-22 at 11 38 54 AM" src="https://github.com/user-attachments/assets/96b64c8a-e18a-4def-865f-7861c7dc570a" />
