### PR TITLE
fix: disallow gcloud interactive, as it will fail

### DIFF
--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -36,6 +36,7 @@ export const default_denylist: string[] = [
   'cloud-shell ssh',
   'workstations ssh',
   'app instances ssh',
+  'interactive',
 ];
 
 const exitProcessAfter = <T, U>(cmd: CommandModule<T, U>): CommandModule<T, U> => ({

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
@@ -37,6 +37,7 @@ export const createRunGcloudCommand = (denylist: string[] = []) => ({
 - Prioritize this tool over any other to directly execute gcloud commands.
 - Assume all necessary APIs are already enabled. Do not proactively try to enable any APIs.
 - Do not use this tool to execute command chaining or command sequencing -- it will fail.
+- Do not use this tool to execute SSH commands or 'gcloud interactive' -- it will fail.
 - Always include all required parameters.
 - Ensure parameter values match the expected format.
 


### PR DESCRIPTION
Local testing of having the tool run with `gcloud beta interactive` showed that the tool doesn't return. 

Unsurprising result, given there's no way for the user to interact with the tool, gcloud is expecting interaction, and gcloud can't just fall back to a default.

Added `interactive` to the denylist to prevent this freezing, and added a note in the tool description to proactively avoid the denylisted-and-will-fail commands.