### PR TITLE
fix:Update observability gemini install to match the readme naming.

### DIFF
--- a/packages/cloud-observability-mcp/src/gemini_cli_init.test.ts
+++ b/packages/cloud-observability-mcp/src/gemini_cli_init.test.ts
@@ -52,10 +52,10 @@ test('initializeGeminiCLI should create directory and write files', async () => 
   const expectedExtensionJson = {
     name: pkg.name,
     version: pkg.version,
-    description: 'A new MCP-compatible server.',
+    description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
     contextFileName: 'GEMINI.md',
     mcpServers: {
-      'cloud-observability-mcp': {
+      'observability': {
         command: 'npx',
         args: ['-y', '@google-cloud/observability-mcp'],
       },
@@ -105,10 +105,10 @@ test('initializeGeminiCLI should create directory and write files when process.e
   const expectedExtensionJson = {
     name: pkg.name,
     version: pkg.version,
-    description: 'A new MCP-compatible server.',
+    description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
     contextFileName: 'GEMINI.md',
     mcpServers: {
-      'cloud-observability-mcp': {
+      'observability': {
         command: 'npx',
         args: ['-y', '@google-cloud/observability-mcp'],
       },

--- a/packages/cloud-observability-mcp/src/gemini_cli_init.ts
+++ b/packages/cloud-observability-mcp/src/gemini_cli_init.ts
@@ -39,10 +39,10 @@ export const initializeGeminiCLI = async (
     const extensionJson = {
       name: pkg.name,
       version: pkg.version,
-      description: 'A new MCP-compatible server.',
+      description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
       contextFileName: 'GEMINI.md',
       mcpServers: {
-        'cloud-observability-mcp': {
+        'observability': {
           command: 'npx',
           args: ['-y', '@google-cloud/observability-mcp'],
         },


### PR DESCRIPTION
The proposal was to drop the `-mcp` from both of the MCP servers, and the `cloud-` from Observability's.