### PR TITLE
fix: Update observability initialization to match gcloud init

### DIFF
--- a/packages/cloud-observability-mcp/src/commands/init-gemini-cli.test.ts
+++ b/packages/cloud-observability-mcp/src/commands/init-gemini-cli.test.ts
@@ -15,9 +15,9 @@
  */
 
 import { test, expect, vi, beforeEach } from 'vitest';
-import { initializeGeminiCLI } from './gemini_cli_init.js';
+import { initializeGeminiCLI } from './init-gemini-cli.js';
 import { join } from 'path';
-import pkg from '../package.json' with { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/cloud-observability-mcp/src/commands/init-gemini-cli.ts
+++ b/packages/cloud-observability-mcp/src/commands/init-gemini-cli.ts
@@ -17,7 +17,7 @@
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import pkg from '../package.json' with { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 export const initializeGeminiCLI = async (
   fs = { mkdir, readFile, writeFile }
@@ -27,6 +27,7 @@ export const initializeGeminiCLI = async (
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 
+    // Create directory
     const extensionDir = join(
       cwd,
       '.gemini',
@@ -35,6 +36,7 @@ export const initializeGeminiCLI = async (
     );
     await fs.mkdir(extensionDir, { recursive: true });
 
+    // Create gemini-extension.json
     const extensionFile = join(extensionDir, 'gemini-extension.json');
     const extensionJson = {
       name: pkg.name,
@@ -53,7 +55,7 @@ export const initializeGeminiCLI = async (
     // eslint-disable-next-line no-console
     console.log(`Created: ${extensionFile}`);
 
-    const geminiMdSrcPath = join(__dirname, '../GEMINI-extension.md');
+    const geminiMdSrcPath = join(__dirname, '../../GEMINI-extension.md');
     const geminiMdDestPath = join(extensionDir, 'GEMINI.md');
     const geminiMdContent = await fs.readFile(geminiMdSrcPath);
     await fs.writeFile(geminiMdDestPath, geminiMdContent);

--- a/packages/cloud-observability-mcp/src/commands/init.test.ts
+++ b/packages/cloud-observability-mcp/src/commands/init.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { init } from './init.js';
+import { initializeGeminiCLI } from './init-gemini-cli.js';
+
+vi.mock('./init-gemini-cli.js', () => ({
+  initializeGeminiCLI: vi.fn(),
+}));
+
+describe('init', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should initialize gemini when agent is gemini-cli', async () => {
+    const argv = {
+      agent: 'gemini-cli',
+      $0: 'test',
+      _: [],
+    };
+    await init.handler(argv);
+    expect(initializeGeminiCLI).toHaveBeenCalled();
+  });
+
+  it('should throw an error if agent is not gemini-cli', async () => {
+    const argv = {
+      agent: 'not-gemini-cli',
+      $0: 'test',
+      _: [],
+    };
+    await expect(init.handler(argv)).rejects.toThrow('Unknown agent: not-gemini-cli');
+    expect(initializeGeminiCLI).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-observability-mcp/src/commands/init.ts
+++ b/packages/cloud-observability-mcp/src/commands/init.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Argv, ArgumentsCamelCase, CommandModule } from 'yargs';
+import { initializeGeminiCLI } from './init-gemini-cli.js';
+
+interface InstallArgs {
+  agent: string;
+}
+
+export const init: CommandModule<object, InstallArgs> = {
+  command: 'init',
+  describe: 'Initialize the MCP server with an agent.',
+  builder: (yargs: Argv) =>
+    yargs.option('agent', {
+      describe: 'The agent to initialize the MCP server with.',
+      type: 'string',
+      choices: ['gemini-cli'] as const,
+      demandOption: true,
+    }),
+  handler: async (argv: ArgumentsCamelCase<InstallArgs>) => {
+    if (argv.agent === 'gemini-cli') {
+      await initializeGeminiCLI();
+    } else {
+      throw new Error(`Unknown agent: ${argv.agent}`);
+    }
+  },
+};


### PR DESCRIPTION
fix: Update observability initialization to match gcloud init

This update should align the observability-mcp and gcloud-mcp init commands. It also unifies some of the behaviors of the base MCP Server as well.

```
$ npx -y @google-cloud/observability-mcp init --agent=gemini-cli
Created: /usr/local/google/home/wjacquette/gcloud-mcp/.gemini/extensions/cloud-observability-mcp/gemini-extension.json
Created: /usr/local/google/home/wjacquette/gcloud-mcp/.gemini/extensions/cloud-observability-mcp/GEMINI.md
🌱 cloud-observability-mcp Gemini CLI extension initialized.
```