### PR TITLE
ci: add renovate-bot configurations

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run gts
+      - name: Run lint
         run: |
           npm run fix
           git diff --exit-code

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "schedule:weekly"
-  ],
+  "extends": ["config:base", "schedule:weekly"],
   "automerge": false,
   "stabilityDays": 7,
   "packageRules": [


### PR DESCRIPTION
* Weekly updates
* Only uses dependencies that have soaked for 7 days to increase likelihood of finding issues prior to merging.
* Automerge disabled
* Only non-major dependency updates are grouped together. Major updates will be distinct PRs.