### PR TITLE
fix: invisible character

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For example, for gcloud and observability:
 }
 ```
 
-## 🛠️ Local Development
+## 🛠 Local Development
 
 For more information regarding installing the repository locally, please see [development.md](doc/DEVELOPMENT.md)
 


### PR DESCRIPTION
invisible character accidentally pasted in. This caused some issues with the short links in the readme


<img width="920" height="124" alt="Screenshot 2025-08-29 at 11 29 39 AM" src="https://github.com/user-attachments/assets/50764e89-4ab2-4411-95b9-188dde848215" />

