### PR TITLE
fix: ignore linting for release-please generated  changelogs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/**/CHANGELOG.md


### PR DESCRIPTION
This PR ignores linting on release-please generated changelogs (rather than trying to modify the prettier configuration to adhere to release-please).

See #84 for exampling linting failure with the current configuration.