### PR TITLE
chore: add observability-mcp to release-please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  "packages/gcloud-mcp": "0.0.0"
+  "packages/gcloud-mcp": "0.0.0",
+  "packages/observability-mcp": "0.0.0"
 }


### PR DESCRIPTION
I believe this is what's required for release-please to pick up the observability package in its automation.