### PR TITLE
chore: set release-as version to 0.1.0 in release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-as": "0.1.0",
   "packages": {
     "packages/gcloud-mcp": {},
     "packages/observability-mcp": {}


### PR DESCRIPTION
Current local testing shows the configuration releases as 1.0.0