### PR TITLE
chore: release-please bootstrap SHA set to avoid non-conventional initial commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "b57cea402695c844ca3da20633b1f30f9a372048",
   "release-as": "0.1.0",
   "packages": {
     "packages/gcloud-mcp": {},


### PR DESCRIPTION
Resolving error:
> ❯ commit could not be parsed: 29fe32fa5e08ca018f446b4744231a639790165e init
> ❯ error message: Error: unexpected token EOF at 1:5, valid tokens [(, !, :]