### PR TITLE
fix: update gemini cli extension name

### DIFF
--- a/packages/gcloud-mcp/src/commands/init-gemini-cli.test.ts
+++ b/packages/gcloud-mcp/src/commands/init-gemini-cli.test.ts
@@ -52,7 +52,7 @@ test('initializeGeminiCLI should create directory and write files', async () => 
 
   // Verify gemini-extension.json content
   const expectedExtensionJson = {
-    name: pkg.name,
+    name: 'gcloud-mcp',
     version: pkg.version,
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
     contextFileName: 'GEMINI.md',
@@ -97,7 +97,7 @@ test('initializeGeminiCLI should create directory and write files when process.e
 
   // Verify gemini-extension.json content
   const expectedExtensionJson = {
-    name: pkg.name,
+    name: 'gcloud-mcp',
     version: pkg.version,
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
     contextFileName: 'GEMINI.md',
@@ -158,7 +158,7 @@ test('initializeGeminiCLI should create directory and write files with local=tru
 
   // Verify gemini-extension.json content
   const expectedExtensionJson = {
-    name: pkg.name + ' [LOCAL]',
+    name: 'gcloud-mcp-local',
     version: pkg.version,
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
     contextFileName: 'GEMINI.md',

--- a/packages/gcloud-mcp/src/commands/init-gemini-cli.ts
+++ b/packages/gcloud-mcp/src/commands/init-gemini-cli.ts
@@ -36,7 +36,7 @@ export const initializeGeminiCLI = async (local = false, fs = { mkdir, readFile,
     // Create gemini-extension.json
     const extensionFile = join(extensionDir, 'gemini-extension.json');
     const extensionJson = {
-      name: pkg.name + (local ? ' [LOCAL]' : ''),
+      name: 'gcloud-mcp' + (local ? '-local' : ''),
       version: pkg.version,
       description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
       contextFileName: 'GEMINI.md',

--- a/packages/observability-mcp/src/commands/init-gemini-cli.test.ts
+++ b/packages/observability-mcp/src/commands/init-gemini-cli.test.ts
@@ -45,7 +45,7 @@ test('initializeGeminiCLI should create directory and write files', async () => 
 
   // Verify gemini-extension.json content
   const expectedExtensionJson = {
-    name: pkg.name,
+    name: 'observability-mcp',
     version: pkg.version,
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
     contextFileName: 'GEMINI.md',
@@ -90,7 +90,7 @@ test('initializeGeminiCLI should create directory and write files when process.e
 
   // Verify gemini-extension.json content
   const expectedExtensionJson = {
-    name: pkg.name,
+    name: 'observability-mcp',
     version: pkg.version,
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
     contextFileName: 'GEMINI.md',
@@ -154,7 +154,7 @@ test('initializeGeminiCLI should create directory and write files with local=tru
 
   // Verify gemini-extension.json content
   const expectedExtensionJson = {
-    name: pkg.name + ' [LOCAL]',
+    name: 'observability-mcp-local',
     version: pkg.version,
     description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
     contextFileName: 'GEMINI.md',

--- a/packages/observability-mcp/src/commands/init-gemini-cli.ts
+++ b/packages/observability-mcp/src/commands/init-gemini-cli.ts
@@ -32,7 +32,7 @@ export const initializeGeminiCLI = async (local = false, fs = { mkdir, readFile,
     // Create gemini-extension.json
     const extensionFile = join(extensionDir, 'gemini-extension.json');
     const extensionJson = {
-      name: pkg.name + (local ? ' [LOCAL]' : ''),
+      name: 'observability-mcp' + (local ? '-local' : ''),
       version: pkg.version,
       description: 'Enable MCP-compatible AI agents to interact with Google Cloud Observability.',
       contextFileName: 'GEMINI.md',


### PR DESCRIPTION
As an initial fix for https://github.com/google-gemini/gemini-cli/pull/7065 to allow the migration to succeed, the extension name of the mcp servers are standardized to not have directory (slash) notation in the extension name. This causes issue when gemini CLI goes to find the extensions.json file.

To test this on a clean worksapce:
1) Install nightly gemini-cli -- `npm install -g @google/gemini-cli@nightly`
2) init an mcp server a project level dir: `gcloud-mcp init --agent=gemini-cli --local`
3) Run `gemini` then accept prompt to migrate
4) rerun `gemini` and mcp server should be working with no extension warning at gemini start.


A follow up PR to this may include removing the workspace-level install in favor of the root / home level `/gemini/extensions` install.