### PR TITLE
fix: standardize install to home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,7 @@ To integrate gcloud MCP with Gemini CLI or Gemini Code Assist, you can run a
 single setup command. This will configure it as a
 [Gemini CLI extension](https://github.com/google-gemini/gemini-cli/blob/main/docs/extension.md).
 
-To make the MCP server(s) available for all your projects, run the command in
-your home directory. This will install the MCP server as a Gemini CLI extension
-globally for the current user.
-
-Alternatively, to make the MCP server(s) available for a specific project, run
-the command from your project's root directory.
+To make the MCP server(s) available for all your projects, run the following command. This will install the MCP server as a Gemini CLI extension globally for the current user.
 
 ```shell
 npx @google-cloud/[PACKAGE_NAME] init --agent=gemini-cli

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ To integrate gcloud MCP with Gemini CLI or Gemini Code Assist, you can run a
 single setup command. This will configure it as a
 [Gemini CLI extension](https://github.com/google-gemini/gemini-cli/blob/main/docs/extension.md).
 
-To make the MCP server(s) available for all your projects, run the following command. This will install the MCP server as a Gemini CLI extension globally for the current user.
+To make the MCP server(s) available for all your projects, run the command in
+your home directory. This will install the MCP server as a Gemini CLI extension
+globally for the current user.
+
+Alternatively, to make the MCP server(s) available for a specific project, run
+the command from your project's root directory.
 
 ```shell
 npx @google-cloud/[PACKAGE_NAME] init --agent=gemini-cli

--- a/packages/gcloud-mcp/src/commands/init-gemini-cli.test.ts
+++ b/packages/gcloud-mcp/src/commands/init-gemini-cli.test.ts
@@ -19,6 +19,7 @@ import { initializeGeminiCLI } from './init-gemini-cli.js';
 import { join } from 'path';
 import pkg from '../../package.json' with { type: 'json' };
 import { log } from '../utility/logger.js';
+import os from 'os';
 
 vi.mock('../utility/logger.js', () => ({
   log: {
@@ -26,13 +27,19 @@ vi.mock('../utility/logger.js', () => ({
   },
 }));
 
+vi.mock('os', () => ({
+  default: {
+    homedir: vi.fn(),
+  },
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
-  delete process.env['INIT_CWD'];
 });
 
 test('initializeGeminiCLI should create directory and write files', async () => {
-  process.env['INIT_CWD'] = '/test/cwd';
+  const homedir = '/test/home';
+  vi.spyOn(os, 'homedir').mockReturnValue(homedir);
   const mockMkdir = vi.fn();
   const mockWriteFile = vi.fn();
   const mockReadFile = vi.fn().mockResolvedValue('Test content for GEMINI.md');
@@ -43,52 +50,7 @@ test('initializeGeminiCLI should create directory and write files', async () => 
     readFile: mockReadFile,
   });
 
-  const extensionDir = join('/test/cwd', '.gemini', 'extensions', 'gcloud-mcp');
-  const extensionFile = join(extensionDir, 'gemini-extension.json');
-  const geminiMdDestPath = join(extensionDir, 'GEMINI.md');
-
-  // Verify directory creation
-  expect(mockMkdir).toHaveBeenCalledWith(extensionDir, { recursive: true });
-
-  // Verify gemini-extension.json content
-  const expectedExtensionJson = {
-    name: 'gcloud-mcp',
-    version: pkg.version,
-    description: 'Enable MCP-compatible AI agents to interact with Google Cloud.',
-    contextFileName: 'GEMINI.md',
-    mcpServers: {
-      gcloud: {
-        command: 'npx',
-        args: ['-y', '@google-cloud/gcloud-mcp'],
-      },
-    },
-  };
-  expect(mockWriteFile).toHaveBeenCalledWith(
-    extensionFile,
-    JSON.stringify(expectedExtensionJson, null, 2),
-  );
-
-  // Verify GEMINI.md reading and writing
-  expect(mockReadFile).toHaveBeenCalled();
-  expect(mockWriteFile).toHaveBeenCalledWith(geminiMdDestPath, 'Test content for GEMINI.md');
-});
-
-test('initializeGeminiCLI should create directory and write files when process.env[init_cwd] is not set', async () => {
-  const fakecwd = '/fakecwd';
-  const spy = vi.spyOn(process, 'cwd');
-  spy.mockReturnValue(fakecwd);
-
-  const mockMkdir = vi.fn();
-  const mockWriteFile = vi.fn();
-  const mockReadFile = vi.fn().mockResolvedValue('Test content for GEMINI.md');
-
-  await initializeGeminiCLI(undefined, {
-    mkdir: mockMkdir,
-    writeFile: mockWriteFile,
-    readFile: mockReadFile,
-  });
-
-  const extensionDir = join(fakecwd, '.gemini', 'extensions', 'gcloud-mcp');
+  const extensionDir = join(homedir, '.gemini', 'extensions', 'gcloud-mcp');
   const extensionFile = join(extensionDir, 'gemini-extension.json');
   const geminiMdDestPath = join(extensionDir, 'GEMINI.md');
 
@@ -138,7 +100,8 @@ test('initializeGeminiCLI should log error if mkdir fails', async () => {
 });
 
 test('initializeGeminiCLI should create directory and write files with local=true', async () => {
-  process.env['INIT_CWD'] = '/test/cwd';
+  const homedir = '/test/home';
+  vi.spyOn(os, 'homedir').mockReturnValue(homedir);
   const mockMkdir = vi.fn();
   const mockWriteFile = vi.fn();
   const mockReadFile = vi.fn().mockResolvedValue('Test content for GEMINI.md');
@@ -149,7 +112,7 @@ test('initializeGeminiCLI should create directory and write files with local=tru
     readFile: mockReadFile,
   });
 
-  const extensionDir = join('/test/cwd', '.gemini', 'extensions', 'gcloud-mcp');
+  const extensionDir = join(homedir, '.gemini', 'extensions', 'gcloud-mcp');
   const extensionFile = join(extensionDir, 'gemini-extension.json');
   const geminiMdDestPath = join(extensionDir, 'GEMINI.md');
 

--- a/packages/gcloud-mcp/src/commands/init-gemini-cli.ts
+++ b/packages/gcloud-mcp/src/commands/init-gemini-cli.ts
@@ -19,18 +19,15 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import pkg from '../../package.json' with { type: 'json' };
 import { log } from '../utility/logger.js';
+import os from 'os';
 
 export const initializeGeminiCLI = async (local = false, fs = { mkdir, readFile, writeFile }) => {
   try {
-    // When running `npm start -w [workspace]`, npm sets the CWD to the workspace directory.
-    // INIT_CWD is an environment variable set by npm that holds the original CWD.
-    // Use the original CWD if it exists, otherwise use the process' CWD.
-    const cwd = process.env['INIT_CWD'] || process.cwd();
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 
     // Create directory
-    const extensionDir = join(cwd, '.gemini', 'extensions', 'gcloud-mcp');
+    const extensionDir = join(os.homedir(), '.gemini', 'extensions', 'gcloud-mcp');
     await fs.mkdir(extensionDir, { recursive: true });
 
     // Create gemini-extension.json

--- a/packages/observability-mcp/src/commands/init-gemini-cli.ts
+++ b/packages/observability-mcp/src/commands/init-gemini-cli.ts
@@ -18,15 +18,15 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import pkg from '../../package.json' with { type: 'json' };
+import os from 'os';
 
 export const initializeGeminiCLI = async (local = false, fs = { mkdir, readFile, writeFile }) => {
   try {
-    const cwd = process.env['INIT_CWD'] || process.cwd();
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
 
     // Create directory
-    const extensionDir = join(cwd, '.gemini', 'extensions', 'observability-mcp');
+    const extensionDir = join(os.homedir(), '.gemini', 'extensions', 'observability-mcp');
     await fs.mkdir(extensionDir, { recursive: true });
 
     // Create gemini-extension.json

--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -25,6 +25,8 @@ steps:
         npm link
         cd ../..
         npm install -g @google/gemini-cli
+        echo "Gemini CLI version:"
+        gemini --version
 
         echo "--- Initializing servers with Gemini CLI"
         npx gcloud-mcp init --agent=gemini-cli --local


### PR DESCRIPTION
With the introduction of https://github.com/google-gemini/gemini-cli/pull/7065 -- Gemini CLI's new guidance is to install extensions at the user/home level instead of at the project/workspace level. This still works well with our local development flow as the bin command is available at that level.

If we do not include this change, users of Gemini CLI will be prompted to migrate their extensions to home dir.