### PR TITLE
ci: updating Release Please manifest for gcloud-mcp to have 0.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/gcloud-mcp": "0.0.0",
+  "packages/gcloud-mcp": "0.1.0",
   "packages/observability-mcp": "0.1.0"
 }


### PR DESCRIPTION
In https://github.com/googleapis/gcloud-mcp/pull/189, Release Please didn't recognize the latest release of 0.1.0, probably because this file is still pointing to 0.1.0.

<img width="1280" height="310" alt="image" src="https://github.com/user-attachments/assets/a85d5b47-3c05-419d-b3a0-1d0184b08937" />
