### PR TITLE
ci: remove release-as in the Release Please config file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "b57cea402695c844ca3da20633b1f30f9a372048",
-  "release-as": "0.1.0",
   "packages": {
     "packages/gcloud-mcp": {},
     "packages/observability-mcp": {}


### PR DESCRIPTION
Removed the 'release-as' version from the config.