### PR TITLE
ci: skip coverage for dependabot PRs

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -61,6 +61,7 @@ jobs:
           npm run test:i
 
   coverage:
+    if: github.actor != 'dependabot[bot]'
     name: Coverage
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Dependabot does not have access to repository secrets even if the PR is not coming from a fork. See: https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions

Since dependency updates should not affect coverage, we can simply skip it.

Fixes #196