### PR TITLE
ci: investigating Release Please's gcloud-mcp

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/gcloud-mcp": "0.1.0",
+  "packages/gcloud-mcp": "0.1.1",
   "packages/observability-mcp": "0.1.1"
 }


### PR DESCRIPTION
The 0.1.1 release for gcloud-mcp package was done in https://github.com/googleapis/gcloud-mcp/releases/tag/gcloud-mcp-v0.1.1 earlier today. Still Release Please is trying to make 0.1.1 release. This file should have been updated to have 0.1.1 in https://github.com/googleapis/gcloud-mcp/pull/204.