### PR TITLE
Docs updatedocs: improve Local Development guide with clarity, cleanup steps, and example

### DIFF
--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -36,10 +36,10 @@ npx gcloud-mcp init --agent=gemini-cli --local
 
 ### 📊 Local vs Remote Comparison
 
-| Mode             | Where it points                           | When to use |
-|------------------|-------------------------------------------|-------------|
-| `--local`        | Local npm link (`gcloud-mcp` inside repo) | When developing/testing changes in your fork/clone |
-| _(no flag)_      | Remote npm registry (`@google-cloud/gcloud-mcp`) | When using the published package |
+| Mode        | Where it points                                  | When to use                                        |
+| ----------- | ------------------------------------------------ | -------------------------------------------------- |
+| `--local`   | Local npm link (`gcloud-mcp` inside repo)        | When developing/testing changes in your fork/clone |
+| _(no flag)_ | Remote npm registry (`@google-cloud/gcloud-mcp`) | When using the published package                   |
 
 ---
 
@@ -76,6 +76,6 @@ Then re-run `npx gcloud-mcp init --agent=gemini-cli` **without** the `--local` f
 
 ### 🛠️ Troubleshooting
 
-- **Command not found** → Ensure you ran `npm link` inside the correct `packages/<mcp_server_name>` folder.  
-- **Client not reflecting changes** → Check whether you initialized with `--local` or not.  
-- **Conflicts with global install** → Run the cleanup/reset steps and reinstall cleanly.  
+- **Command not found** → Ensure you ran `npm link` inside the correct `packages/<mcp_server_name>` folder.··
+- **Client not reflecting changes** → Check whether you initialized with `--local` or not.··
+- **Conflicts with global install** → Run the cleanup/reset steps and reinstall cleanly.··

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -2,77 +2,80 @@
 
 ## Setup
 
-### Clone the Github Repository
+### Clone the GitHub Repository
 
-```shell
+```bash
 git clone https://github.com/googleapis/gcloud-mcp.git
-```
-
-This will create a directory named `gcloud-mcp` in your current working directory. Go ahead and `cd` into that directory:
-
-```shell
 cd gcloud-mcp
 ```
 
+This will create a directory named `gcloud-mcp` and move you into it.
+
+---
+
 ### Install the gcloud-mcp Server
 
-```shell
+```bash
 npm install
-cd packages/<mcp_server_name>  # For example: packages/gcloud-mcp
-npm link  # Makes the bin command available globally. For example "gcloud-mcp" available globally
-npm install -g @google/gemini-cli  # If not already installed
+cd packages/<mcp_server_name>   # Example: packages/gcloud-mcp
+npm link                        # Makes the bin command (e.g. "gcloud-mcp") available globally
+npm install -g @google/gemini-cli   # If not already installed
 ```
+
+---
 
 ### Initialize the gcloud-mcp Server with Gemini CLI
 
-```shell
+```bash
 npx gcloud-mcp init --agent=gemini-cli --local
 ```
 
-**NOTE: The `--local` flag changes what installation the client's MCP server configuration is pointing to (local or global).**
+**NOTE: The `--local` flag changes where the client’s MCP server configuration points (local or remote).**
 
-**WITHOUT the `--local` flag:**
+---
 
-```json
-"mcpServers": {
-    "gcloud": {
-        "command": "npx",
-        "args": [
-        "-y",
-        // References the npm remote registry UNLESS extension file inside repository directory.
-        "@google-cloud/gcloud-mcp"
-        ]
-    }
-}
-```
+### 📊 Local vs Remote Comparison
 
-The above server configuration will always be pulling from the remote npm registry, **UNLESS** the `init` command was run inside of your local `gcloud-mcp` repository.
+| Mode             | Where it points                           | When to use |
+|------------------|-------------------------------------------|-------------|
+| `--local`        | Local npm link (`gcloud-mcp` inside repo) | When developing/testing changes in your fork/clone |
+| _(no flag)_      | Remote npm registry (`@google-cloud/gcloud-mcp`) | When using the published package |
 
-**WITH the `--local` flag:**
+---
 
-```json
-"mcpServers": {
-    "gcloud": {
-        "command": "npx",
-        "args": [
-        "-y",
-        // References the LOCAL npm installation
-        "gcloud-mcp"
-        ]
-    }
-}
-```
+### Example Walkthrough
 
-### Let's run through an example:
-
-```shell
+```bash
 # Inside ~/usr/local/username/development/gcloud-mcp
-npx gcloud-mcp init --agent=gemini-cli  # This create the extension file pointing to REMOTE
-gemini # The client will reflect local changes since the extension file was initialized inside the project directory.
+npx gcloud-mcp init --agent=gemini-cli
+gemini   # The client reflects local changes since init ran inside the repo
 
 cd ~/usr/local/username/development/my-other-project
 npx gcloud-mcp init --agent=gemini-cli
-gemini  # The client will NOT reflect local changes since the extension file is pointing to the REMOTE registry.
+gemini   # The client will NOT reflect local changes (points to remote registry)
+
 npx gcloud-mcp init --agent=gemini-cli --local
-gemini  # The client will reflect local changes since the extension file is pointing to the LOCAL install.
+gemini   # Now the client reflects local changes (points to local install)
 ```
+
+---
+
+### 🧹 Cleanup / Reset
+
+If you want to unlink your local installation and return to the remote registry:
+
+```bash
+cd packages/gcloud-mcp
+npm unlink
+npm uninstall -g gcloud-mcp
+```
+
+Then re-run `npx gcloud-mcp init --agent=gemini-cli` **without** the `--local` flag.
+
+---
+
+### 🛠️ Troubleshooting
+
+- **Command not found** → Ensure you ran `npm link` inside the correct `packages/<mcp_server_name>` folder.  
+- **Client not reflecting changes** → Check whether you initialized with `--local` or not.  
+- **Conflicts with global install** → Run the cleanup/reset steps and reinstall cleanly.  


### PR DESCRIPTION
This pull request updates the `DEVELOPMENT.md` guide to make it more comprehensive and easier to follow for local development.

The following improvements were made:
- Added a clear step-by-step setup guide for cloning and installing the gcloud-mcp server.
- Provided a breakdown of the `--local` vs. remote flags for initializing the server.
- Included an example walkthrough to better illustrate the local development workflow.
- Added a new "Cleanup / Reset" section to help users unlink their local installation and revert to the remote registry.

This update should help new and existing developers more easily set up and troubleshoot their local development environment.