### PR TITLE
feat: parameterize gemini cli release version

### DIFF
--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  _GEMINI_CLI_RELEASE_VERSION: '@latest'
+  _GEMINI_CLI_RELEASE_VERSION: 'latest'
 steps:
   - name: 'node:20'
     entrypoint: 'bash'
@@ -26,7 +26,7 @@ steps:
         cd packages/observability-mcp
         npm link
         cd ../..
-        npm install -g @google/gemini-cli$_GEMINI_CLI_RELEASE_VERSION
+        npm install -g @google/gemini-cli@$_GEMINI_CLI_RELEASE_VERSION
         echo "Gemini CLI version:"
         gemini --version
 


### PR DESCRIPTION
In order to test on upcoming versions of Gemini CLI, the integration test will be parameterized. Then additional triggers will be added to run post-merge on nightly / preview builds as well.