### PR TITLE
feat: add meta commands to default denylist

### DIFF
--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -36,6 +36,7 @@ export const default_denylist: string[] = [
   'workstations ssh',
   'app instances ssh',
   'interactive',
+  'meta',
 ];
 
 const exitProcessAfter = <T, U>(cmd: CommandModule<T, U>): CommandModule<T, U> => ({


### PR DESCRIPTION
Meta commands are not intended for general use. Note, this does not impact linting as it works independent of the `run_gcloud_command` denylist.

See also b/445546854