### PR TITLE
chore: bump gcloud-mcp to 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/gcloud-mcp": "0.1.1",
+  "packages/gcloud-mcp": "0.2.0",
   "packages/observability-mcp": "0.1.1"
 }


### PR DESCRIPTION
Manually editing the manifest file until b/444669596 is resolved.