### PR TITLE
chore: 2-week dependency soak time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "schedule:weekly"],
   "automerge": false,
-  "stabilityDays": 7,
+  "stabilityDays": 14,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Update from 1 week to 2 weeks for dependency soak time aligned with go/airlock/repositories#level-1-repositories.