### PR TITLE
feat: auto recover with release track

### DIFF
--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
@@ -574,5 +574,37 @@ Invoke this tool again with this alternative command to fix the issue.`,
         isError: true,
       });
     });
+    test('non-allowlisted GA command suggests beta', async () => {
+      const tool = createTool({ allow: ['beta compute'] });
+      const inputArgs = ['compute', 'instances', 'list'];
+      (gcloud.lint as Mock)
+        .mockResolvedValueOnce({
+          code: 1,
+          stdout: `[{"command_string_no_args": "gcloud compute instances list"}]`,
+          stderr: 'not found',
+        })
+        .mockResolvedValueOnce({
+          code: 0,
+          stdout: `[{"command_string_no_args": "gcloud beta compute instances list"}]`,
+          stderr: '',
+        });
+
+      const result = await tool({ args: inputArgs });
+
+      expect(gcloud.invoke).not.toHaveBeenCalled();
+      expect(gcloud.lint).toHaveBeenCalledTimes(2);
+      expect(gcloud.lint).toHaveBeenCalledWith('beta compute instances list');
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: `Execution denied: The command 'gcloud compute instances list' is not on the allowlist.
+However, a similar command is available: 'gcloud beta compute instances list'.
+Invoke this tool again with this alternative command to fix the issue.`,
+          },
+        ],
+        isError: true,
+      });
+    });
   });
 });

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
@@ -67,6 +67,8 @@ async function findAlternativeCommand(
       } else {
         alternativeCommandWithAllArgs.splice(trackIndex, 1);
       }
+    } else {
+      alternativeCommandWithAllArgs.unshift(t);
     }
 
     const { code } = await gcloud.lint(alternativeCommandWithAllArgs.join(' '));


### PR DESCRIPTION
Automatically suggest an appropriate track if available.

<img width="1240" height="261" alt="Screenshot 2025-10-13 at 1 36 08 PM" src="https://github.com/user-attachments/assets/103111cf-b13d-4e39-9f3e-13d42237c897" />
