### PR TITLE
fix: gcs text decoding with iconv-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9214,6 +9214,7 @@
         "chardet": "^2.1.0",
         "google-auth-library": "^9.11.0",
         "googleapis": "^140.0.0",
+        "iconv-lite": "^0.7.0",
         "mime-types": "^2.1.35",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -9339,6 +9340,21 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "packages/storage-mcp/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "packages/storage-mcp/node_modules/mime-db": {

--- a/packages/storage-mcp/package.json
+++ b/packages/storage-mcp/package.json
@@ -63,6 +63,7 @@
     "chardet": "^2.1.0",
     "google-auth-library": "^9.11.0",
     "googleapis": "^140.0.0",
+    "iconv-lite": "^0.7.0",
     "mime-types": "^2.1.35",
     "yargs": "^18.0.0",
     "zod": "^3.25.76"

--- a/packages/storage-mcp/src/tools/objects/read_object_content.ts
+++ b/packages/storage-mcp/src/tools/objects/read_object_content.ts
@@ -15,6 +15,8 @@
  */
 
 import chardet from 'chardet';
+import iconv from 'iconv-lite';
+const { decode } = iconv;
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
@@ -101,7 +103,7 @@ export async function readObjectContent(params: ReadObjectContentParams): Promis
     ) {
       try {
         // Try to decode as text.
-        const content = buffer.toString(encoding as BufferEncoding);
+        const content = decode(buffer, encoding);
         const result = {
           bucket: params.bucket_name,
           object: params.object_name,
@@ -115,10 +117,10 @@ export async function readObjectContent(params: ReadObjectContentParams): Promis
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
-      } catch (_e) {
+      } catch (error) {
         // If decoding fails, fall through to treat as a raw resource.
         logger.warn(
-          `Failed to decode ${params.object_name} as text with detected encoding ${encoding}, treating as raw resource.`,
+          `Failed to decode ${params.object_name} as text with detected encoding ${encoding}, treating as raw resource. Error: ${error}`,
         );
       }
     }


### PR DESCRIPTION
I ran into an issue where, when reading a simple csv, the chardet returned the ISO-8859-1 encoding which toString could not handle. This resulted in the MCP server being unable to read files from the bucket. I believe it was looking for something like latin1. iconv-lite is a bit more forgiving her when it comes to decoding.