### PR TITLE
FIX: change from contains matching to regex matching 

### DIFF
--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
         cd packages/observability-mcp
         npm link
         cd ../..
-        npm install -g @google/gemini-cli@$nightly
+        npm install -g @google/gemini-cli@$_GEMINI_CLI_RELEASE_VERSION
         echo "Gemini CLI version:"
         gemini --version
 


### PR DESCRIPTION
Gemini-CLI changed the mcp list output in the latest nightly version.
Changing our integration test to regex matching to be more versatile