### PR TITLE
chore: allow auto-generated googleapis dependency to update major version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "schedule:weekly"],
   "automerge": false,
-  "stabilityDays": 14,
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
@@ -13,7 +13,7 @@
       "matchPackageNames": ["googleapis"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin"],
       "groupName": "standard dependency updates",
-      "stabilityDays": 0
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
Updates the renovatebot configuration to handle googleapis major updates as part of the 'standard' dependency updates group. Giving both rules the same `groupName` tells renovatebot to put these updates in the same PR.