### PR TITLE
feat(gcloud-mcp): add specialized workflow tools

### DIFF
--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -20,6 +20,10 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import pkg from '../package.json' with { type: 'json' };
 import { createRunGcloudCommand } from './tools/run_gcloud_command.js';
+import { createGetGcloudContext } from './tools/get_gcloud_context.js';
+import { createCheckIamPermissions } from './tools/check_iam_permissions.js';
+import { createDeployCloudRun } from './tools/deploy_cloud_run.js';
+import { createSetupProject } from './tools/setup_project.js';
 import * as gcloud from './gcloud.js';
 import yargs, { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -114,6 +118,10 @@ const main = async () => {
   );
   const acl = createAccessControlList(config.allow, [...default_deny, ...(config.deny ?? [])]);
   createRunGcloudCommand(acl).register(server);
+  createGetGcloudContext().register(server);
+  createCheckIamPermissions().register(server);
+  createDeployCloudRun().register(server);
+  createSetupProject().register(server);
   await server.connect(new StdioServerTransport());
   log.info('🚀 gcloud mcp server started');
 

--- a/packages/gcloud-mcp/src/tools/check_iam_permissions.test.ts
+++ b/packages/gcloud-mcp/src/tools/check_iam_permissions.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, test, vi, beforeEach, Mock } from 'vitest';
+import { createCheckIamPermissions } from './check_iam_permissions.js';
+import * as gcloud from '../gcloud.js';
+
+vi.mock('../gcloud.js');
+
+const mockServer = {
+  registerTool: vi.fn(),
+} as unknown as McpServer;
+
+const getToolImplementation = () => {
+  expect(mockServer.registerTool).toHaveBeenCalledOnce();
+  return (mockServer.registerTool as Mock).mock.calls[0]![2] as (params: {
+    project: string;
+    permissions: string[];
+  }) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+};
+
+const createTool = () => {
+  createCheckIamPermissions().register(mockServer);
+  return getToolImplementation();
+};
+
+describe('check_iam_permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('registers tool with correct name and description', () => {
+    createCheckIamPermissions().register(mockServer);
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'check_iam_permissions',
+      expect.objectContaining({
+        title: 'Check IAM permissions',
+        description: expect.stringContaining('IAM permissions'),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test('returns all granted permissions', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'projects' && args[1] === 'get-iam-policy') {
+        return { code: 0, stdout: 'roles/editor\n', stderr: '' };
+      }
+      if (args[0] === 'projects' && args[1] === 'test-iam-permissions') {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            permissions: ['compute.instances.create', 'storage.buckets.list'],
+          }),
+          stderr: '',
+        };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      permissions: ['compute.instances.create', 'storage.buckets.list'],
+    });
+
+    expect(result.content[0]!.text).toContain('✅ Granted: 2');
+    expect(result.content[0]!.text).toContain('❌ Denied: 0');
+    expect(result.content[0]!.text).toContain('compute.instances.create');
+    expect(result.content[0]!.text).toContain('storage.buckets.list');
+    expect(result.isError).toBeUndefined();
+  });
+
+  test('returns denied permissions with suggestions', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'projects' && args[1] === 'get-iam-policy') {
+        return { code: 0, stdout: 'roles/viewer\n', stderr: '' };
+      }
+      if (args[0] === 'projects' && args[1] === 'test-iam-permissions') {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            permissions: ['storage.buckets.list'],
+          }),
+          stderr: '',
+        };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      permissions: ['compute.instances.create', 'storage.buckets.list'],
+    });
+
+    expect(result.content[0]!.text).toContain('✅ Granted: 1');
+    expect(result.content[0]!.text).toContain('❌ Denied: 1');
+    expect(result.content[0]!.text).toContain('Missing Permissions');
+    expect(result.content[0]!.text).toContain('compute.instances.create');
+  });
+
+  test('handles get-iam-policy failure', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'projects' && args[1] === 'get-iam-policy') {
+        return { code: 1, stdout: '', stderr: 'Permission denied' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      permissions: ['compute.instances.create'],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Permission denied');
+  });
+
+  test('handles test-iam-permissions failure', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'projects' && args[1] === 'get-iam-policy') {
+        return { code: 0, stdout: 'roles/editor\n', stderr: '' };
+      }
+      if (args[0] === 'projects' && args[1] === 'test-iam-permissions') {
+        return { code: 1, stdout: '', stderr: 'API not enabled' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      permissions: ['compute.instances.create'],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('API not enabled');
+  });
+
+  test('handles invalid JSON response gracefully', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'projects' && args[1] === 'get-iam-policy') {
+        return { code: 0, stdout: 'roles/editor\n', stderr: '' };
+      }
+      if (args[0] === 'projects' && args[1] === 'test-iam-permissions') {
+        return { code: 0, stdout: 'not valid json', stderr: '' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      permissions: ['compute.instances.create'],
+    });
+
+    expect(result.content[0]!.text).toContain('❌ Denied: 1');
+  });
+
+  test('handles gcloud invocation error', async () => {
+    vi.mocked(gcloud.invoke).mockRejectedValue(new Error('gcloud not found'));
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      permissions: ['compute.instances.create'],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Failed to check IAM permissions');
+    expect(result.content[0]!.text).toContain('gcloud not found');
+  });
+});

--- a/packages/gcloud-mcp/src/tools/check_iam_permissions.ts
+++ b/packages/gcloud-mcp/src/tools/check_iam_permissions.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as gcloud from '../gcloud.js';
+import { log } from '../utility/logger.js';
+import { z } from 'zod';
+
+interface PermissionCheckResult {
+  permission: string;
+  granted: boolean;
+}
+
+export const createCheckIamPermissions = () => ({
+  register: (server: McpServer) => {
+    server.registerTool(
+      'check_iam_permissions',
+      {
+        title: 'Check IAM permissions',
+        description: `Checks whether the current authenticated account has specific IAM permissions on a GCP resource.
+
+## Use Cases:
+- Use this tool BEFORE running a command to verify you have the necessary permissions.
+- Use this tool to debug "permission denied" errors by checking which permissions are missing.
+- Use this tool to verify access to a specific project or resource.
+
+## Common Permissions:
+- compute.instances.create - Create VMs
+- storage.buckets.create - Create GCS buckets
+- run.services.create - Deploy Cloud Run services
+- cloudfunctions.functions.create - Deploy Cloud Functions
+- container.clusters.create - Create GKE clusters
+
+## Returns:
+A list of permissions with their granted/denied status.`,
+        inputSchema: {
+          project: z.string().describe('The GCP project ID to check permissions against'),
+          permissions: z
+            .array(z.string())
+            .describe(
+              'List of IAM permissions to check (e.g., ["compute.instances.create", "storage.buckets.list"])',
+            ),
+        },
+      },
+      async ({ project, permissions }) => {
+        const toolLogger = log.mcp('check_iam_permissions', { project, permissions });
+        toolLogger.info('Checking IAM permissions');
+
+        try {
+          const results: PermissionCheckResult[] = [];
+
+          const policyResult = await gcloud.invoke([
+            'projects',
+            'get-iam-policy',
+            project,
+            '--flatten=bindings[].members',
+            '--format=value(bindings.role)',
+            '--filter=bindings.members:*',
+          ]);
+
+          if (policyResult.code !== 0) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Failed to check permissions: ${policyResult.stderr || 'Unknown error'}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const testResult = await gcloud.invoke([
+            'projects',
+            'test-iam-permissions',
+            project,
+            `--permissions=${permissions.join(',')}`,
+            '--format=json',
+          ]);
+
+          if (testResult.code !== 0) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Failed to test permissions: ${testResult.stderr || 'Unknown error'}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          let grantedPermissions: string[] = [];
+          try {
+            const parsed = JSON.parse(testResult.stdout);
+            grantedPermissions = parsed.permissions || [];
+          } catch {
+            grantedPermissions = [];
+          }
+
+          for (const permission of permissions) {
+            results.push({
+              permission,
+              granted: grantedPermissions.includes(permission),
+            });
+          }
+
+          const granted = results.filter((r) => r.granted);
+          const denied = results.filter((r) => !r.granted);
+
+          let output = `# IAM Permission Check Results
+
+**Project:** ${project}
+
+## Summary
+- ✅ Granted: ${granted.length}
+- ❌ Denied: ${denied.length}
+
+## Details
+
+| Permission | Status |
+|------------|--------|
+`;
+
+          for (const result of results) {
+            const status = result.granted ? '✅ Granted' : '❌ Denied';
+            output += `| ${result.permission} | ${status} |\n`;
+          }
+
+          if (denied.length > 0) {
+            output += `
+## Missing Permissions
+
+The following permissions are not granted to your account:
+${denied.map((d) => `- ${d.permission}`).join('\n')}
+
+To request these permissions, contact your project administrator or request a role that includes them.`;
+          }
+
+          return {
+            content: [{ type: 'text', text: output }],
+          };
+        } catch (e: unknown) {
+          toolLogger.error(
+            'check_iam_permissions failed',
+            e instanceof Error ? e : new Error(String(e)),
+          );
+          const msg = e instanceof Error ? e.message : 'An unknown error occurred.';
+          return {
+            content: [{ type: 'text', text: `Failed to check IAM permissions: ${msg}` }],
+            isError: true,
+          };
+        }
+      },
+    );
+  },
+});

--- a/packages/gcloud-mcp/src/tools/deploy_cloud_run.test.ts
+++ b/packages/gcloud-mcp/src/tools/deploy_cloud_run.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, test, vi, beforeEach, Mock } from 'vitest';
+import { createDeployCloudRun } from './deploy_cloud_run.js';
+import * as gcloud from '../gcloud.js';
+
+vi.mock('../gcloud.js');
+
+const mockServer = {
+  registerTool: vi.fn(),
+} as unknown as McpServer;
+
+const getToolImplementation = () => {
+  expect(mockServer.registerTool).toHaveBeenCalledOnce();
+  return (mockServer.registerTool as Mock).mock.calls[0]![2] as (params: {
+    serviceName: string;
+    image: string;
+    region: string;
+    project?: string;
+    allowUnauthenticated?: boolean;
+    memory?: string;
+    cpu?: string;
+    envVars?: Record<string, string>;
+    port?: number;
+    minInstances?: number;
+    maxInstances?: number;
+  }) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+};
+
+const createTool = () => {
+  createDeployCloudRun().register(mockServer);
+  return getToolImplementation();
+};
+
+describe('deploy_cloud_run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('registers tool with correct name and description', () => {
+    createDeployCloudRun().register(mockServer);
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'deploy_cloud_run',
+      expect.objectContaining({
+        title: 'Deploy to Cloud Run',
+        description: expect.stringContaining('Cloud Run'),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test('deploys service successfully with URL from JSON response', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'run' && args[1] === 'deploy') {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            status: { url: 'https://my-service-abc123.run.app' },
+          }),
+          stderr: '',
+        };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      serviceName: 'my-service',
+      image: 'gcr.io/my-project/my-image:latest',
+      region: 'us-central1',
+    });
+
+    expect(result.content[0]!.text).toContain('Cloud Run Deployment Complete');
+    expect(result.content[0]!.text).toContain('my-service');
+    expect(result.content[0]!.text).toContain('https://my-service-abc123.run.app');
+    expect(result.isError).toBeUndefined();
+  });
+
+  test('includes all optional parameters in deploy command', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({ status: { url: 'https://test.run.app' } }),
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool({
+      serviceName: 'my-service',
+      image: 'gcr.io/my-project/my-image:latest',
+      region: 'us-central1',
+      project: 'custom-project',
+      allowUnauthenticated: true,
+      memory: '1Gi',
+      cpu: '2',
+      port: 3000,
+      minInstances: 1,
+      maxInstances: 10,
+      envVars: { KEY1: 'value1', KEY2: 'value2' },
+    });
+
+    const deployCall = invokeSpy.mock.calls[0]![0];
+    expect(deployCall).toContain('--project');
+    expect(deployCall).toContain('custom-project');
+    expect(deployCall).toContain('--allow-unauthenticated');
+    expect(deployCall).toContain('--memory');
+    expect(deployCall).toContain('1Gi');
+    expect(deployCall).toContain('--cpu');
+    expect(deployCall).toContain('2');
+    expect(deployCall).toContain('--port');
+    expect(deployCall).toContain('3000');
+    expect(deployCall).toContain('--min-instances');
+    expect(deployCall).toContain('1');
+    expect(deployCall).toContain('--max-instances');
+    expect(deployCall).toContain('10');
+    expect(deployCall).toContain('--set-env-vars');
+  });
+
+  test('falls back to describe command for URL', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'run' && args[1] === 'deploy') {
+        return { code: 0, stdout: 'Deploying...', stderr: '' };
+      }
+      if (args[0] === 'run' && args[1] === 'services' && args[2] === 'describe') {
+        return { code: 0, stdout: 'https://fallback-url.run.app\n', stderr: '' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      serviceName: 'my-service',
+      image: 'gcr.io/my-project/my-image:latest',
+      region: 'us-central1',
+    });
+
+    expect(result.content[0]!.text).toContain('https://fallback-url.run.app');
+  });
+
+  test('handles deployment failure', async () => {
+    vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 1,
+      stdout: '',
+      stderr: 'ERROR: (gcloud.run.deploy) Permission denied',
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      serviceName: 'my-service',
+      image: 'gcr.io/my-project/my-image:latest',
+      region: 'us-central1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Deployment Failed');
+    expect(result.content[0]!.text).toContain('Permission denied');
+  });
+
+  test('handles gcloud invocation error', async () => {
+    vi.mocked(gcloud.invoke).mockRejectedValue(new Error('Network error'));
+
+    const tool = createTool();
+    const result = await tool({
+      serviceName: 'my-service',
+      image: 'gcr.io/my-project/my-image:latest',
+      region: 'us-central1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Network error');
+  });
+
+  test('uses no-allow-unauthenticated by default', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({ status: { url: 'https://test.run.app' } }),
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool({
+      serviceName: 'my-service',
+      image: 'gcr.io/my-project/my-image:latest',
+      region: 'us-central1',
+    });
+
+    const deployCall = invokeSpy.mock.calls[0]![0];
+    expect(deployCall).toContain('--no-allow-unauthenticated');
+  });
+});

--- a/packages/gcloud-mcp/src/tools/deploy_cloud_run.ts
+++ b/packages/gcloud-mcp/src/tools/deploy_cloud_run.ts
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as gcloud from '../gcloud.js';
+import { log } from '../utility/logger.js';
+import { z } from 'zod';
+
+interface DeploymentStep {
+  name: string;
+  status: 'pending' | 'running' | 'success' | 'failed';
+  output?: string;
+  error?: string;
+}
+
+export const createDeployCloudRun = () => ({
+  register: (server: McpServer) => {
+    server.registerTool(
+      'deploy_cloud_run',
+      {
+        title: 'Deploy to Cloud Run',
+        description: `Deploys a container image to Cloud Run in a single operation.
+
+## What This Tool Does:
+1. Deploys the specified container image to Cloud Run
+2. Waits for the deployment to complete
+3. Returns the service URL
+
+## Use Cases:
+- Deploy a new Cloud Run service from a container image
+- Update an existing Cloud Run service with a new image
+- Deploy with specific configuration (memory, CPU, environment variables)
+
+## Prerequisites:
+- Container image must already exist in a registry (e.g., gcr.io, Artifact Registry)
+- Cloud Run API must be enabled in the project
+- Appropriate IAM permissions (run.services.create, run.services.update)
+
+## Returns:
+The deployed service URL and deployment status.`,
+        inputSchema: {
+          serviceName: z.string().describe('Name of the Cloud Run service'),
+          image: z
+            .string()
+            .describe(
+              'Container image to deploy (e.g., gcr.io/project/image:tag or us-docker.pkg.dev/project/repo/image:tag)',
+            ),
+          region: z.string().describe('GCP region to deploy to (e.g., us-central1, europe-west1)'),
+          project: z.string().optional().describe('GCP project ID (uses default if not specified)'),
+          allowUnauthenticated: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe('Allow unauthenticated access to the service'),
+          memory: z
+            .string()
+            .optional()
+            .describe('Memory limit (e.g., 512Mi, 1Gi, 2Gi). Default: 512Mi'),
+          cpu: z.string().optional().describe('CPU limit (e.g., 1, 2). Default: 1'),
+          envVars: z
+            .record(z.string())
+            .optional()
+            .describe('Environment variables as key-value pairs'),
+          port: z.number().optional().describe('Container port. Default: 8080'),
+          minInstances: z.number().optional().describe('Minimum number of instances'),
+          maxInstances: z.number().optional().describe('Maximum number of instances'),
+        },
+      },
+      async ({
+        serviceName,
+        image,
+        region,
+        project,
+        allowUnauthenticated,
+        memory,
+        cpu,
+        envVars,
+        port,
+        minInstances,
+        maxInstances,
+      }) => {
+        const toolLogger = log.mcp('deploy_cloud_run', { serviceName, image, region });
+        toolLogger.info('Starting Cloud Run deployment');
+
+        const steps: DeploymentStep[] = [];
+
+        const addStep = (name: string): DeploymentStep => {
+          const step: DeploymentStep = { name, status: 'pending' };
+          steps.push(step);
+          return step;
+        };
+
+        const formatSteps = (): string =>
+          steps
+            .map((s) => {
+              const icon =
+                s.status === 'success'
+                  ? '✅'
+                  : s.status === 'failed'
+                    ? '❌'
+                    : s.status === 'running'
+                      ? '⏳'
+                      : '⬚';
+              return `${icon} ${s.name}${s.error ? `: ${s.error}` : ''}`;
+            })
+            .join('\n');
+
+        try {
+          const deployStep = addStep('Deploy to Cloud Run');
+          deployStep.status = 'running';
+
+          const args = ['run', 'deploy', serviceName, '--image', image, '--region', region];
+
+          if (project) {
+            args.push('--project', project);
+          }
+
+          if (allowUnauthenticated) {
+            args.push('--allow-unauthenticated');
+          } else {
+            args.push('--no-allow-unauthenticated');
+          }
+
+          if (memory) {
+            args.push('--memory', memory);
+          }
+
+          if (cpu) {
+            args.push('--cpu', cpu);
+          }
+
+          if (port) {
+            args.push('--port', port.toString());
+          }
+
+          if (minInstances !== undefined) {
+            args.push('--min-instances', minInstances.toString());
+          }
+
+          if (maxInstances !== undefined) {
+            args.push('--max-instances', maxInstances.toString());
+          }
+
+          if (envVars && Object.keys(envVars).length > 0) {
+            const envString = Object.entries(envVars)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(',');
+            args.push('--set-env-vars', envString);
+          }
+
+          args.push('--format=json');
+
+          const deployResult = await gcloud.invoke(args);
+
+          if (deployResult.code !== 0) {
+            deployStep.status = 'failed';
+            deployStep.error = deployResult.stderr || 'Deployment failed';
+
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `# Cloud Run Deployment Failed
+
+## Steps
+${formatSteps()}
+
+## Error Details
+\`\`\`
+${deployResult.stderr}
+\`\`\``,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          deployStep.status = 'success';
+
+          let serviceUrl = '';
+          try {
+            const deployOutput = JSON.parse(deployResult.stdout);
+            serviceUrl = deployOutput.status?.url || '';
+          } catch {
+            const urlMatch = deployResult.stdout.match(/https:\/\/[^\s]+\.run\.app/);
+            if (urlMatch) {
+              serviceUrl = urlMatch[0];
+            }
+          }
+
+          const getUrlStep = addStep('Get service URL');
+          getUrlStep.status = 'running';
+
+          if (!serviceUrl) {
+            const describeResult = await gcloud.invoke([
+              'run',
+              'services',
+              'describe',
+              serviceName,
+              '--region',
+              region,
+              ...(project ? ['--project', project] : []),
+              '--format=value(status.url)',
+            ]);
+
+            if (describeResult.code === 0) {
+              serviceUrl = describeResult.stdout.trim();
+            }
+          }
+
+          getUrlStep.status = serviceUrl ? 'success' : 'failed';
+
+          const output = `# Cloud Run Deployment Complete
+
+## Service Details
+| Property | Value |
+|----------|-------|
+| Service Name | ${serviceName} |
+| Region | ${region} |
+| Image | ${image} |
+| URL | ${serviceUrl || '(unavailable)'} |
+
+## Steps
+${formatSteps()}
+
+## Next Steps
+${serviceUrl ? `- Test your service: \`curl ${serviceUrl}\`` : ''}
+- View logs: \`gcloud run services logs read ${serviceName} --region=${region}\`
+- Update service: Use this tool again with a new image tag`;
+
+          return {
+            content: [{ type: 'text', text: output }],
+          };
+        } catch (e: unknown) {
+          toolLogger.error(
+            'deploy_cloud_run failed',
+            e instanceof Error ? e : new Error(String(e)),
+          );
+          const msg = e instanceof Error ? e.message : 'An unknown error occurred.';
+          return {
+            content: [{ type: 'text', text: `# Cloud Run Deployment Failed\n\nError: ${msg}` }],
+            isError: true,
+          };
+        }
+      },
+    );
+  },
+});

--- a/packages/gcloud-mcp/src/tools/get_gcloud_context.test.ts
+++ b/packages/gcloud-mcp/src/tools/get_gcloud_context.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, test, vi, beforeEach, Mock } from 'vitest';
+import { createGetGcloudContext } from './get_gcloud_context.js';
+import * as gcloud from '../gcloud.js';
+
+vi.mock('../gcloud.js');
+
+const mockServer = {
+  registerTool: vi.fn(),
+} as unknown as McpServer;
+
+const getToolImplementation = () => {
+  expect(mockServer.registerTool).toHaveBeenCalledOnce();
+  return (mockServer.registerTool as Mock).mock.calls[0]![2] as () => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+};
+
+const createTool = () => {
+  createGetGcloudContext().register(mockServer);
+  return getToolImplementation();
+};
+
+describe('get_gcloud_context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('registers tool with correct name and description', () => {
+    createGetGcloudContext().register(mockServer);
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'get_gcloud_context',
+      expect.objectContaining({
+        title: 'Get gcloud context',
+        description: expect.stringContaining('current gcloud CLI context'),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test('returns all context values when set', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      const command = args.join(' ');
+      if (command.includes('account')) {
+        return { code: 0, stdout: 'user@example.com\n', stderr: '' };
+      }
+      if (command.includes('project')) {
+        return { code: 0, stdout: 'my-project-123\n', stderr: '' };
+      }
+      if (command.includes('compute/region')) {
+        return { code: 0, stdout: 'us-central1\n', stderr: '' };
+      }
+      if (command.includes('compute/zone')) {
+        return { code: 0, stdout: 'us-central1-a\n', stderr: '' };
+      }
+      if (command.includes('configurations')) {
+        return { code: 0, stdout: 'my-config\n', stderr: '' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool();
+
+    expect(result.content[0]!.text).toContain('user@example.com');
+    expect(result.content[0]!.text).toContain('my-project-123');
+    expect(result.content[0]!.text).toContain('us-central1');
+    expect(result.content[0]!.text).toContain('us-central1-a');
+    expect(result.content[0]!.text).toContain('my-config');
+    expect(result.isError).toBeUndefined();
+  });
+
+  test('handles unset values gracefully', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      const command = args.join(' ');
+      if (command.includes('account')) {
+        return { code: 0, stdout: 'user@example.com\n', stderr: '' };
+      }
+      if (command.includes('configurations')) {
+        return { code: 0, stdout: 'default\n', stderr: '' };
+      }
+      return { code: 0, stdout: '(unset)\n', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool();
+
+    expect(result.content[0]!.text).toContain('user@example.com');
+    expect(result.content[0]!.text).toContain('(not set)');
+    expect(result.content[0]!.text).toContain('## Note');
+    expect(result.content[0]!.text).toContain('project');
+    expect(result.content[0]!.text).toContain('region');
+    expect(result.content[0]!.text).toContain('zone');
+  });
+
+  test('handles empty string values', async () => {
+    vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    const result = await tool();
+
+    expect(result.content[0]!.text).toContain('(not set)');
+  });
+
+  test('returns error when gcloud invocation fails', async () => {
+    vi.mocked(gcloud.invoke).mockRejectedValue(new Error('gcloud not found'));
+
+    const tool = createTool();
+    const result = await tool();
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Failed to get gcloud context');
+    expect(result.content[0]!.text).toContain('gcloud not found');
+  });
+
+  test('executes all config queries in parallel', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: 'value\n',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool();
+
+    expect(invokeSpy).toHaveBeenCalledTimes(5);
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'get-value', 'account']);
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'get-value', 'project']);
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'get-value', 'compute/region']);
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'get-value', 'compute/zone']);
+    expect(invokeSpy).toHaveBeenCalledWith([
+      'config',
+      'configurations',
+      'list',
+      '--filter=is_active=true',
+      '--format=value(name)',
+    ]);
+  });
+});

--- a/packages/gcloud-mcp/src/tools/get_gcloud_context.ts
+++ b/packages/gcloud-mcp/src/tools/get_gcloud_context.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as gcloud from '../gcloud.js';
+import { log } from '../utility/logger.js';
+
+interface GcloudContext {
+  account: string | null;
+  project: string | null;
+  region: string | null;
+  zone: string | null;
+  configuration: string | null;
+}
+
+const parseConfigValue = (output: string): string | null => {
+  const trimmed = output.trim();
+  return trimmed === '' || trimmed === '(unset)' ? null : trimmed;
+};
+
+export const createGetGcloudContext = () => ({
+  register: (server: McpServer) => {
+    server.registerTool(
+      'get_gcloud_context',
+      {
+        title: 'Get gcloud context',
+        description: `Returns the current gcloud CLI context including active account, project, region, zone, and configuration name.
+
+## Use Cases:
+- Use this tool at the start of a session to understand the current GCP environment.
+- Use this tool to verify which project/account will be used before executing commands.
+- Use this tool when the user asks about their current GCP configuration.
+
+## Returns:
+- account: The active GCP account email
+- project: The default project ID
+- region: The default compute region
+- zone: The default compute zone
+- configuration: The active gcloud configuration name`,
+        inputSchema: {},
+      },
+      async () => {
+        const toolLogger = log.mcp('get_gcloud_context', {});
+        toolLogger.info('Fetching gcloud context');
+
+        try {
+          const [accountResult, projectResult, regionResult, zoneResult, configResult] =
+            await Promise.all([
+              gcloud.invoke(['config', 'get-value', 'account']),
+              gcloud.invoke(['config', 'get-value', 'project']),
+              gcloud.invoke(['config', 'get-value', 'compute/region']),
+              gcloud.invoke(['config', 'get-value', 'compute/zone']),
+              gcloud.invoke([
+                'config',
+                'configurations',
+                'list',
+                '--filter=is_active=true',
+                '--format=value(name)',
+              ]),
+            ]);
+
+          const context: GcloudContext = {
+            account: parseConfigValue(accountResult.stdout),
+            project: parseConfigValue(projectResult.stdout),
+            region: parseConfigValue(regionResult.stdout),
+            zone: parseConfigValue(zoneResult.stdout),
+            configuration: parseConfigValue(configResult.stdout),
+          };
+
+          const missingFields: string[] = [];
+          if (!context.project) missingFields.push('project');
+          if (!context.region) missingFields.push('region');
+          if (!context.zone) missingFields.push('zone');
+
+          let output = `# Current gcloud Context
+
+| Property | Value |
+|----------|-------|
+| Account | ${context.account ?? '(not set)'} |
+| Project | ${context.project ?? '(not set)'} |
+| Region | ${context.region ?? '(not set)'} |
+| Zone | ${context.zone ?? '(not set)'} |
+| Configuration | ${context.configuration ?? 'default'} |
+`;
+
+          if (missingFields.length > 0) {
+            output += `
+## Note
+The following properties are not set: ${missingFields.join(', ')}.
+Some commands may require these values to be specified explicitly.`;
+          }
+
+          return {
+            content: [{ type: 'text', text: output }],
+          };
+        } catch (e: unknown) {
+          toolLogger.error(
+            'get_gcloud_context failed',
+            e instanceof Error ? e : new Error(String(e)),
+          );
+          const msg = e instanceof Error ? e.message : 'An unknown error occurred.';
+          return {
+            content: [{ type: 'text', text: `Failed to get gcloud context: ${msg}` }],
+            isError: true,
+          };
+        }
+      },
+    );
+  },
+});

--- a/packages/gcloud-mcp/src/tools/setup_project.test.ts
+++ b/packages/gcloud-mcp/src/tools/setup_project.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, test, vi, beforeEach, Mock } from 'vitest';
+import { createSetupProject } from './setup_project.js';
+import * as gcloud from '../gcloud.js';
+
+vi.mock('../gcloud.js');
+
+const mockServer = {
+  registerTool: vi.fn(),
+} as unknown as McpServer;
+
+const getToolImplementation = () => {
+  expect(mockServer.registerTool).toHaveBeenCalledOnce();
+  return (mockServer.registerTool as Mock).mock.calls[0]![2] as (params: {
+    project: string;
+    enableApis?: string[];
+    region?: string;
+    zone?: string;
+    setAsDefault?: boolean;
+  }) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+};
+
+const createTool = () => {
+  createSetupProject().register(mockServer);
+  return getToolImplementation();
+};
+
+describe('setup_project', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('registers tool with correct name and description', () => {
+    createSetupProject().register(mockServer);
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'setup_project',
+      expect.objectContaining({
+        title: 'Setup GCP project',
+        description: expect.stringContaining('GCP project'),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test('sets project as default', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      setAsDefault: true,
+    });
+
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'set', 'project', 'my-project']);
+    expect(result.content[0]!.text).toContain('Set default project');
+    expect(result.content[0]!.text).toContain('✅');
+  });
+
+  test('enables API groups correctly', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool({
+      project: 'my-project',
+      enableApis: ['cloud-run'],
+      setAsDefault: false,
+    });
+
+    expect(invokeSpy).toHaveBeenCalledWith([
+      'services',
+      'enable',
+      'run.googleapis.com',
+      '--project',
+      'my-project',
+    ]);
+    expect(invokeSpy).toHaveBeenCalledWith([
+      'services',
+      'enable',
+      'artifactregistry.googleapis.com',
+      '--project',
+      'my-project',
+    ]);
+  });
+
+  test('enables explicit API names', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool({
+      project: 'my-project',
+      enableApis: ['custom.googleapis.com'],
+      setAsDefault: false,
+    });
+
+    expect(invokeSpy).toHaveBeenCalledWith([
+      'services',
+      'enable',
+      'custom.googleapis.com',
+      '--project',
+      'my-project',
+    ]);
+  });
+
+  test('sets region and zone', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool({
+      project: 'my-project',
+      region: 'us-central1',
+      zone: 'us-central1-a',
+      setAsDefault: false,
+    });
+
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'set', 'compute/region', 'us-central1']);
+    expect(invokeSpy).toHaveBeenCalledWith(['config', 'set', 'compute/zone', 'us-central1-a']);
+  });
+
+  test('reports failed steps', async () => {
+    vi.mocked(gcloud.invoke).mockImplementation(async (args: string[]) => {
+      if (args.includes('services')) {
+        return { code: 1, stdout: '', stderr: 'Permission denied' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      enableApis: ['compute'],
+      setAsDefault: true,
+    });
+
+    expect(result.content[0]!.text).toContain('Completed with Errors');
+    expect(result.content[0]!.text).toContain('❌');
+    expect(result.content[0]!.text).toContain('Permission denied');
+    expect(result.isError).toBe(true);
+  });
+
+  test('handles gcloud invocation error', async () => {
+    vi.mocked(gcloud.invoke).mockRejectedValue(new Error('Connection failed'));
+
+    const tool = createTool();
+    const result = await tool({
+      project: 'my-project',
+      setAsDefault: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('GCP Project Setup Failed');
+    expect(result.content[0]!.text).toContain('Connection failed');
+  });
+
+  test('deduplicates APIs', async () => {
+    const invokeSpy = vi.mocked(gcloud.invoke).mockResolvedValue({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    const tool = createTool();
+    await tool({
+      project: 'my-project',
+      enableApis: ['compute', 'compute.googleapis.com'],
+      setAsDefault: false,
+    });
+
+    const enableCalls = invokeSpy.mock.calls.filter(
+      (call) => call[0]![0] === 'services' && call[0]![1] === 'enable',
+    );
+    expect(enableCalls.length).toBe(1);
+  });
+});

--- a/packages/gcloud-mcp/src/tools/setup_project.ts
+++ b/packages/gcloud-mcp/src/tools/setup_project.ts
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as gcloud from '../gcloud.js';
+import { log } from '../utility/logger.js';
+import { z } from 'zod';
+
+interface SetupStep {
+  name: string;
+  status: 'pending' | 'running' | 'success' | 'failed' | 'skipped';
+  output?: string;
+  error?: string;
+}
+
+const COMMON_APIS: Record<string, string[]> = {
+  compute: ['compute.googleapis.com'],
+  storage: ['storage.googleapis.com'],
+  'cloud-run': ['run.googleapis.com', 'artifactregistry.googleapis.com'],
+  'cloud-functions': ['cloudfunctions.googleapis.com', 'cloudbuild.googleapis.com'],
+  kubernetes: ['container.googleapis.com'],
+  bigquery: ['bigquery.googleapis.com'],
+  pubsub: ['pubsub.googleapis.com'],
+  firestore: ['firestore.googleapis.com'],
+  'cloud-sql': ['sqladmin.googleapis.com'],
+};
+
+export const createSetupProject = () => ({
+  register: (server: McpServer) => {
+    server.registerTool(
+      'setup_project',
+      {
+        title: 'Setup GCP project',
+        description: `Configures a GCP project by enabling APIs and setting default region/zone in a single operation.
+
+## What This Tool Does:
+1. Enables specified GCP APIs
+2. Sets default compute region and zone
+3. Sets the project as the default in gcloud config
+
+## Use Cases:
+- Bootstrap a new GCP project for development
+- Enable multiple APIs at once (e.g., for a Cloud Run + Firestore app)
+- Configure project defaults after creation
+
+## Available API Groups:
+- compute: Compute Engine API
+- storage: Cloud Storage API
+- cloud-run: Cloud Run + Artifact Registry APIs
+- cloud-functions: Cloud Functions + Cloud Build APIs
+- kubernetes: Google Kubernetes Engine API
+- bigquery: BigQuery API
+- pubsub: Pub/Sub API
+- firestore: Firestore API
+- cloud-sql: Cloud SQL Admin API
+
+## Returns:
+Status of each configuration step.`,
+        inputSchema: {
+          project: z.string().describe('GCP project ID to configure'),
+          enableApis: z
+            .array(z.string())
+            .optional()
+            .describe(
+              'API groups to enable (e.g., ["compute", "storage", "cloud-run"]) or specific API names (e.g., ["run.googleapis.com"])',
+            ),
+          region: z
+            .string()
+            .optional()
+            .describe('Default compute region to set (e.g., us-central1)'),
+          zone: z.string().optional().describe('Default compute zone to set (e.g., us-central1-a)'),
+          setAsDefault: z
+            .boolean()
+            .optional()
+            .default(true)
+            .describe('Set this project as the default in gcloud config'),
+        },
+      },
+      async ({ project, enableApis, region, zone, setAsDefault }) => {
+        const toolLogger = log.mcp('setup_project', { project, enableApis, region, zone });
+        toolLogger.info('Setting up GCP project');
+
+        const steps: SetupStep[] = [];
+
+        const addStep = (name: string): SetupStep => {
+          const step: SetupStep = { name, status: 'pending' };
+          steps.push(step);
+          return step;
+        };
+
+        const formatSteps = (): string =>
+          steps
+            .map((s) => {
+              const icon =
+                s.status === 'success'
+                  ? '✅'
+                  : s.status === 'failed'
+                    ? '❌'
+                    : s.status === 'skipped'
+                      ? '⏭️'
+                      : s.status === 'running'
+                        ? '⏳'
+                        : '⬚';
+              let line = `${icon} ${s.name}`;
+              if (s.error) {
+                line += `\n   Error: ${s.error}`;
+              }
+              return line;
+            })
+            .join('\n');
+
+        try {
+          if (setAsDefault) {
+            const setProjectStep = addStep('Set default project');
+            setProjectStep.status = 'running';
+
+            const setProjectResult = await gcloud.invoke(['config', 'set', 'project', project]);
+
+            if (setProjectResult.code !== 0) {
+              setProjectStep.status = 'failed';
+              setProjectStep.error = setProjectResult.stderr;
+            } else {
+              setProjectStep.status = 'success';
+            }
+          }
+
+          if (enableApis && enableApis.length > 0) {
+            const apisToEnable: string[] = [];
+
+            for (const api of enableApis) {
+              if (COMMON_APIS[api]) {
+                apisToEnable.push(...COMMON_APIS[api]!);
+              } else if (api.includes('.googleapis.com')) {
+                apisToEnable.push(api);
+              } else {
+                apisToEnable.push(`${api}.googleapis.com`);
+              }
+            }
+
+            const uniqueApis = [...new Set(apisToEnable)];
+
+            for (const api of uniqueApis) {
+              const enableStep = addStep(`Enable ${api}`);
+              enableStep.status = 'running';
+
+              const enableResult = await gcloud.invoke([
+                'services',
+                'enable',
+                api,
+                '--project',
+                project,
+              ]);
+
+              if (enableResult.code !== 0) {
+                enableStep.status = 'failed';
+                enableStep.error = enableResult.stderr;
+              } else {
+                enableStep.status = 'success';
+              }
+            }
+          }
+
+          if (region) {
+            const setRegionStep = addStep(`Set default region: ${region}`);
+            setRegionStep.status = 'running';
+
+            const setRegionResult = await gcloud.invoke([
+              'config',
+              'set',
+              'compute/region',
+              region,
+            ]);
+
+            if (setRegionResult.code !== 0) {
+              setRegionStep.status = 'failed';
+              setRegionStep.error = setRegionResult.stderr;
+            } else {
+              setRegionStep.status = 'success';
+            }
+          }
+
+          if (zone) {
+            const setZoneStep = addStep(`Set default zone: ${zone}`);
+            setZoneStep.status = 'running';
+
+            const setZoneResult = await gcloud.invoke(['config', 'set', 'compute/zone', zone]);
+
+            if (setZoneResult.code !== 0) {
+              setZoneStep.status = 'failed';
+              setZoneStep.error = setZoneResult.stderr;
+            } else {
+              setZoneStep.status = 'success';
+            }
+          }
+
+          const failedSteps = steps.filter((s) => s.status === 'failed');
+          const successSteps = steps.filter((s) => s.status === 'success');
+
+          const output = `# GCP Project Setup ${failedSteps.length > 0 ? 'Completed with Errors' : 'Complete'}
+
+## Project: ${project}
+
+## Configuration Steps
+${formatSteps()}
+
+## Summary
+- ✅ Successful: ${successSteps.length}
+- ❌ Failed: ${failedSteps.length}
+${
+  failedSteps.length > 0
+    ? `
+## Troubleshooting
+Some steps failed. Common causes:
+- Missing permissions (need roles/owner or roles/serviceusage.serviceUsageAdmin)
+- API quota exceeded
+- Invalid region/zone name
+
+Run \`gcloud projects get-iam-policy ${project}\` to check your permissions.`
+    : ''
+}
+## Next Steps
+- Run \`get_gcloud_context\` to verify the configuration
+- Use \`check_iam_permissions\` to verify your access`;
+
+          return {
+            content: [{ type: 'text', text: output }],
+            isError: failedSteps.length > 0,
+          };
+        } catch (e: unknown) {
+          toolLogger.error('setup_project failed', e instanceof Error ? e : new Error(String(e)));
+          const msg = e instanceof Error ? e.message : 'An unknown error occurred.';
+          return {
+            content: [{ type: 'text', text: `# GCP Project Setup Failed\n\nError: ${msg}` }],
+            isError: true,
+          };
+        }
+      },
+    );
+  },
+});


### PR DESCRIPTION
## Summary

This PR adds four new specialized tools to improve agent productivity and reduce common errors:

### 1. `get_gcloud_context` (#323)
Returns current account, project, region, zone, and configuration name in a single call by running queries in parallel. 
- **Use case**: Verify environment before executing commands, debug configuration issues

### 2. `check_iam_permissions` (#324)  
Tests whether the authenticated account has specific IAM permissions on a project.
- **Use case**: Proactively check permissions before running commands, debug "permission denied" errors
- **Related to**: #169 (reduce IAM errors)

### 3. `deploy_cloud_run` (#325)
Deploys a container image to Cloud Run with a clean interface.
- **Supports**: memory, CPU, port, min/max instances, env vars, allow-unauthenticated
- **Use case**: Single-command deployments without memorizing gcloud syntax

### 4. `setup_project` (#326)
Bootstraps a GCP project by enabling APIs and setting defaults.
- **Supports**: Friendly API group names that expand automatically:
  - `cloud-run` → run.googleapis.com + artifactregistry.googleapis.com
  - `cloud-functions` → cloudfunctions.googleapis.com + cloudbuild.googleapis.com
  - etc.
- **Use case**: Quick project setup for development

## Test Plan

- [x] 28 new unit tests added (all passing)
- [x] `npm test` passes with 327 total tests
- [x] `npm run lint` passes
- [x] Each tool has error handling and helpful output formatting

## Related Issues

For #323, #324, #325, #326
Related to #168 (provide gcloud context), #169 (reduce IAM errors)