### PR TITLE
fix: correct broken Gemini CLI extension documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ servers hosted outside of this repo are
 To integrate MCP servers with Gemini CLI or Gemini Code Assist, run the setup
 command below from your home directory for MCP server listed in the table. This
 will install the MCP server as a
-[Gemini CLI extension](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md).
+[Gemini CLI extension](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions).
 for the current user, making it available for all your projects.
 
 ```shell


### PR DESCRIPTION
## Description

Fixes the broken documentation link in the README that was pointing to a 404 URL.

### Changes
- Updated the Gemini CLI extension link from `https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md` to `https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions`

This resolves the 404 error on line 48 of README.md.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)