### PR TITLE
feat(storage-mcp): add safe download object tool and mark original as destructive

### DIFF
--- a/packages/storage-mcp/README.md
+++ b/packages/storage-mcp/README.md
@@ -149,7 +149,7 @@ ones. They will never modify or delete existing data in GCS.
 | `list_objects`              | Lists objects in a GCS bucket.                                                                                              |
 | `read_object_metadata`      | Reads comprehensive metadata for a specific object.                                                                         |
 | `read_object_content`       | Reads the content of a specific object.                                                                                     |
-| `download_object`           | Downloads an object from GCS to a local file.                                                                               |
+| `download_object_safe`      | Downloads an object from GCS to a local file. Fails if the destination file already exists.                                 |
 | `write_object_new`          | Writes a new object. Fails if the object already exists.                                                                    |
 | `upload_object_new`         | Uploads a file to a new object. Fails if the object already exists.                                                         |
 | `copy_object_new`           | Copies an object to a new destination. Fails if the destination already exists.                                             |
@@ -173,6 +173,7 @@ counterparts (e.g., `write_object` is registered instead of `write_object_new`).
 | `update_bucket_labels`   | **Modifies** labels for a bucket.                          |
 | `delete_object`          | **Deletes** a specific object from a bucket.               |
 | `update_object_metadata` | **Modifies** the custom metadata of an existing object.    |
+| `download_object`        | Downloads an object, **overwriting** the destination file. |
 | `move_object`            | **Moves** an object (copies then deletes the original).    |
 | `write_object`           | Writes an object, **overwriting** it if it already exists. |
 | `upload_object`          | Uploads a file, **overwriting** the destination object.    |

--- a/packages/storage-mcp/src/tools/index.ts
+++ b/packages/storage-mcp/src/tools/index.ts
@@ -29,6 +29,7 @@ import {
   registerCopyObjectSafeTool,
   registerDeleteObjectTool,
   registerDownloadObjectTool,
+  registerDownloadObjectSafeTool,
   registerListObjectsTool,
   registerMoveObjectTool,
   registerReadObjectContentTool,
@@ -55,7 +56,7 @@ export const commonSafeTools = [
   registerListObjectsTool,
   registerReadObjectContentTool,
   registerReadObjectMetadataTool,
-  registerDownloadObjectTool,
+  registerDownloadObjectSafeTool,
   registerDeleteObjectTool,
   registerGetMetadataTableSchemaTool,
   registerExecuteInsightsQueryTool,
@@ -79,4 +80,5 @@ export const otherDestructiveTools = [
   registerUpdateBucketLabelsTool,
   registerMoveObjectTool,
   registerUpdateObjectMetadataTool,
+  registerDownloadObjectTool,
 ];

--- a/packages/storage-mcp/src/tools/objects/download_object_safe.test.ts
+++ b/packages/storage-mcp/src/tools/objects/download_object_safe.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { downloadObjectSafe, registerDownloadObjectSafeTool } from './download_object_safe';
+import { apiClientFactory } from '../../utility/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+vi.mock('../../utility/index.js');
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js');
+vi.mock('fs');
+
+describe('downloadObjectSafe', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should download an object and return success when destination does not exist', async () => {
+    const { default: fs } = await import('fs');
+    (fs.existsSync as vi.Mock).mockReturnValue(false);
+
+    const mockDownload = vi.fn().mockResolvedValue(undefined);
+    const mockFile = vi.fn(() => ({
+      download: mockDownload,
+    }));
+    const mockBucket = vi.fn(() => ({
+      file: mockFile,
+    }));
+    const mockStorageClient = {
+      bucket: mockBucket,
+    };
+
+    (apiClientFactory.getStorageClient as vi.Mock).mockReturnValue(mockStorageClient);
+
+    const result = await downloadObjectSafe({
+      bucket_name: 'test-bucket',
+      object_name: 'test-object.txt',
+      file_path: '/tmp/test-object.txt',
+    });
+
+    expect(fs.existsSync).toHaveBeenCalledWith('/tmp/test-object.txt');
+    expect(apiClientFactory.getStorageClient).toHaveBeenCalled();
+    expect(mockBucket).toHaveBeenCalledWith('test-bucket');
+    expect(mockFile).toHaveBeenCalledWith('test-object.txt');
+    expect(mockDownload).toHaveBeenCalledWith({ destination: '/tmp/test-object.txt' });
+    const resultText = JSON.parse(result.content[0].text as string);
+    expect(resultText.success).toBe(true);
+  });
+
+  it('should return AlreadyExists error when destination file already exists', async () => {
+    const { default: fs } = await import('fs');
+    (fs.existsSync as vi.Mock).mockReturnValue(true);
+
+    const result = await downloadObjectSafe({
+      bucket_name: 'test-bucket',
+      object_name: 'test-object.txt',
+      file_path: '/tmp/test-object.txt',
+    });
+
+    expect(apiClientFactory.getStorageClient).not.toHaveBeenCalled();
+    const resultText = JSON.parse(result.content[0].text as string);
+    expect(resultText.success).toBe(false);
+    expect(resultText.error_type).toBe('AlreadyExists');
+    expect(resultText.error).toContain('/tmp/test-object.txt');
+  });
+
+  it('should return an error if the download fails', async () => {
+    const { default: fs } = await import('fs');
+    (fs.existsSync as vi.Mock).mockReturnValue(false);
+
+    const mockDownload = vi.fn().mockRejectedValue(new Error('Download failed'));
+    const mockFile = vi.fn(() => ({
+      download: mockDownload,
+    }));
+    const mockBucket = vi.fn(() => ({
+      file: mockFile,
+    }));
+    const mockStorageClient = {
+      bucket: mockBucket,
+    };
+
+    (apiClientFactory.getStorageClient as vi.Mock).mockReturnValue(mockStorageClient);
+
+    const result = await downloadObjectSafe({
+      bucket_name: 'test-bucket',
+      object_name: 'test-object.txt',
+      file_path: '/tmp/test-object.txt',
+    });
+
+    const resultText = JSON.parse(result.content[0].text as string);
+    expect(resultText.success).toBe(false);
+    expect(resultText.error).toBe('Download failed');
+  });
+});
+
+describe('registerDownloadObjectSafeTool', () => {
+  it('should register the download_object_safe tool with the server', () => {
+    const mockServer = new McpServer();
+    registerDownloadObjectSafeTool(mockServer);
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'download_object_safe',
+      expect.any(Object),
+      downloadObjectSafe,
+    );
+  });
+});

--- a/packages/storage-mcp/src/tools/objects/download_object_safe.ts
+++ b/packages/storage-mcp/src/tools/objects/download_object_safe.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { apiClientFactory } from '../../utility/index.js';
+import { logger } from '../../utility/logger.js';
+
+const inputSchema = {
+  bucket_name: z.string().describe('The name of the GCS bucket.'),
+  object_name: z.string().describe('The name of the object to download.'),
+  file_path: z.string().describe('The local path to save the downloaded file to.'),
+};
+
+type DownloadObjectSafeParams = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export async function downloadObjectSafe(
+  params: DownloadObjectSafeParams,
+): Promise<CallToolResult> {
+  try {
+    if (fs.existsSync(params.file_path)) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: false,
+              error: `File already exists at path: ${params.file_path}`,
+              error_type: 'AlreadyExists',
+            }),
+          },
+        ],
+      };
+    }
+
+    const storage = apiClientFactory.getStorageClient();
+    await storage
+      .bucket(params.bucket_name)
+      .file(params.object_name)
+      .download({ destination: params.file_path });
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            message: `Object ${params.object_name} from bucket ${params.bucket_name} downloaded to ${params.file_path}.`,
+          }),
+        },
+      ],
+    };
+  } catch (e) {
+    const error = e as Error;
+    logger.error(error.message);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            error: error.message,
+          }),
+        },
+      ],
+    };
+  }
+}
+
+export const registerDownloadObjectSafeTool = (server: McpServer) => {
+  server.registerTool(
+    'download_object_safe',
+    {
+      description:
+        'Downloads an object from GCS to a local file. Fails if the destination file already exists.',
+      inputSchema,
+    },
+    downloadObjectSafe,
+  );
+};

--- a/packages/storage-mcp/src/tools/objects/index.ts
+++ b/packages/storage-mcp/src/tools/objects/index.ts
@@ -18,6 +18,7 @@ export * from './copy_object.js';
 export * from './copy_object_safe.js';
 export * from './delete_object.js';
 export * from './download_object.js';
+export * from './download_object_safe.js';
 export * from './list_objects.js';
 export * from './move_object.js';
 export * from './read_object_content.js';


### PR DESCRIPTION
Introduces `download_object_safe` as the default download tool in the common safe tools list, moving the original `download_object` to the destructive tools list.

The current `download_object` tool can overwrite existing file so it should be considered as destructive. The new `download_object_safe` tool will check the existence of the file path so it can be considered safe (similar to the `write_object_safe` tool.