### PR TITLE
fix: quote args containing spaces before passing to lint

### DIFF
--- a/packages/gcloud-mcp/src/shell_join.test.ts
+++ b/packages/gcloud-mcp/src/shell_join.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { shellJoinArgs } from './shell_join.js';
+
+describe('shellJoinArgs', () => {
+  test('joins args without spaces as-is', () => {
+    expect(shellJoinArgs(['logging', 'read', '--limit=10'])).toBe('logging read --limit=10');
+  });
+
+  test('quotes args that contain spaces', () => {
+    expect(
+      shellJoinArgs([
+        'logging',
+        'read',
+        'resource.type=cloud_run_revision AND severity>=WARNING',
+        '--limit=10',
+      ]),
+    ).toBe("logging read 'resource.type=cloud_run_revision AND severity>=WARNING' --limit=10");
+  });
+
+  test('handles multiple args with spaces', () => {
+    expect(shellJoinArgs(['compute', 'instances', 'list', '--filter=name:my instance'])).toBe(
+      "compute instances list '--filter=name:my instance'",
+    );
+  });
+
+  test('returns empty string for empty array', () => {
+    expect(shellJoinArgs([])).toBe('');
+  });
+
+  test('handles single arg without spaces', () => {
+    expect(shellJoinArgs(['list'])).toBe('list');
+  });
+
+  test('handles single arg with spaces', () => {
+    expect(shellJoinArgs(['hello world'])).toBe("'hello world'");
+  });
+});

--- a/packages/gcloud-mcp/src/shell_join.ts
+++ b/packages/gcloud-mcp/src/shell_join.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Joins an array of arguments into a single command string, quoting any
+ * argument that contains spaces so that `gcloud meta lint-gcloud-commands
+ * --command-string` can parse them correctly.
+ *
+ * Without quoting, an argument like
+ *   `resource.type=cloud_run_revision AND severity>=WARNING`
+ * would be split into three separate tokens by the linter, causing an
+ * `UnrecognizedArgumentsError`.
+ *
+ * @see https://github.com/googleapis/gcloud-mcp/issues/385
+ */
+export const shellJoinArgs = (args: string[]): string =>
+  args.map((arg) => (arg.includes(' ') ? `'${arg}'` : arg)).join(' ');

--- a/packages/gcloud-mcp/src/suggest.ts
+++ b/packages/gcloud-mcp/src/suggest.ts
@@ -16,6 +16,7 @@
 
 import { AccessControlList, PRERELEASE_TRACKS_PRIORITIZED } from './denylist.js';
 import * as gcloud from './gcloud.js';
+import { shellJoinArgs } from './shell_join.js';
 
 export const parseReleaseTrack = (cmd: string): string => {
   for (const releaseTrack of PRERELEASE_TRACKS_PRIORITIZED) {
@@ -31,7 +32,7 @@ export async function findSuggestedAlternativeCommand(
   acl: AccessControlList,
   gcloud: gcloud.GcloudExecutable,
 ): Promise<string | null> {
-  const lintResult = await gcloud.lint(originalArgs.join(' '));
+  const lintResult = await gcloud.lint(shellJoinArgs(originalArgs));
   if (!lintResult.success) {
     return null;
   }
@@ -53,7 +54,7 @@ export async function findSuggestedAlternativeCommand(
       altArgs.unshift(releaseTrack);
     }
 
-    const lintResult = await gcloud.lint(altArgs.join(' '));
+    const lintResult = await gcloud.lint(shellJoinArgs(altArgs));
     if (!lintResult.success) {
       continue; // Argument set not valid for this release track.
     }

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
@@ -20,6 +20,7 @@ import { AccessControlList } from '../denylist.js';
 import { findSuggestedAlternativeCommand } from '../suggest.js';
 import { z } from 'zod';
 import { log } from '../utility/logger.js';
+import { shellJoinArgs } from '../shell_join.js';
 
 const suggestionErrorMessage = (suggestedCommand: string) =>
   `Execution denied: This command not permitted. However, a similar command is permitted.
@@ -77,7 +78,7 @@ export const createRunGcloudCommand = (gcloud: GcloudExecutable, acl: AccessCont
           // Example
           //   Given: gcloud compute --log-http=true instance list
           //   Desired command string is: compute instances list
-          const parsedLintResult = await gcloud.lint(args.join(' '));
+          const parsedLintResult = await gcloud.lint(shellJoinArgs(args));
           if (!parsedLintResult.success) {
             return errorTextResult(parsedLintResult.error);
           }


### PR DESCRIPTION
## Problem

`args.join(' ')` on [line 80 of `run_gcloud_command.ts`](https://github.com/googleapis/gcloud-mcp/blob/main/packages/gcloud-mcp/src/tools/run_gcloud_command.ts#L80) destroys argument boundaries when an element contains spaces. For example, a filter expression like:

```
resource.type=cloud_run_revision AND severity>=WARNING
```

…gets flattened into the command string, causing `gcloud meta lint-gcloud-commands` to parse `AND` as a separate argument and throw an `UnrecognizedArgumentsError`.

The actual execution on line 102 (`gcloud.invoke(args)`) correctly passes the original array to `child_process.spawn` — but it never gets there because lint fails first.

The same issue exists in `suggest.ts` where `originalArgs.join(' ')` and `altArgs.join(' ')` are passed to `lint()`.

## Fix

Introduces a shared `shellJoinArgs()` helper that wraps any argument containing a space in single quotes before joining:

```typescript
export const shellJoinArgs = (args: string[]): string =>
  args.map((arg) => (arg.includes(' ') ? \`'${arg}'\` : arg)).join(' ');
```

Applied to both `run_gcloud_command.ts` and `suggest.ts` where args are joined for the lint call.

## Changes

- `packages/gcloud-mcp/src/shell_join.ts` — new shared helper
- `packages/gcloud-mcp/src/shell_join.test.ts` — 6 unit tests (100% coverage)
- `packages/gcloud-mcp/src/tools/run_gcloud_command.ts` — use `shellJoinArgs()` for lint
- `packages/gcloud-mcp/src/suggest.ts` — use `shellJoinArgs()` for lint calls

## Testing

All 114 existing tests pass. New tests cover edge cases (empty arrays, single args, multiple spaces).

Fixes #385