### PR TITLE
feat(storage-mcp): set custom user-agent on Storage client

### DIFF
--- a/packages/storage-mcp/src/tools/buckets/create_bucket.test.ts
+++ b/packages/storage-mcp/src/tools/buckets/create_bucket.test.ts
@@ -45,7 +45,10 @@ describe('createBucket', () => {
       location: 'US',
     });
 
-    expect(Storage).toHaveBeenCalledWith({ projectId: 'test-project' });
+    expect(Storage).toHaveBeenCalledWith({
+      projectId: 'test-project',
+      userAgent: expect.stringMatching(/^gcloud-storage-mcp\//),
+    });
     expect(mockCreateBucket).toHaveBeenCalledWith('test-bucket', {
       location: 'US',
       requesterPays: false,
@@ -83,7 +86,10 @@ describe('createBucket', () => {
       labels: { test: 'label' },
     });
 
-    expect(Storage).toHaveBeenCalledWith({ projectId: 'test-project' });
+    expect(Storage).toHaveBeenCalledWith({
+      projectId: 'test-project',
+      userAgent: expect.stringMatching(/^gcloud-storage-mcp\//),
+    });
     expect(mockCreateBucket).toHaveBeenCalledWith('test-bucket', {
       location: 'US',
       requesterPays: false,

--- a/packages/storage-mcp/src/tools/buckets/create_bucket.ts
+++ b/packages/storage-mcp/src/tools/buckets/create_bucket.ts
@@ -19,6 +19,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { logger } from '../../utility/logger.js';
+import { USER_AGENT } from '../../utility/user_agent.js';
 
 const inputSchema = {
   project_id: z.string().describe('The ID of the GCP project.'),
@@ -47,7 +48,7 @@ type CreateBucketParams = z.infer<z.ZodObject<typeof inputSchema>>;
 export async function createBucket(params: CreateBucketParams): Promise<CallToolResult> {
   try {
     logger.info(`Creating bucket: ${params.bucket_name} in project: ${params.project_id}`);
-    const storage = new Storage({ projectId: params.project_id });
+    const storage = new Storage({ projectId: params.project_id, userAgent: USER_AGENT });
     const options: CreateBucketRequest = {
       location: params.location,
       storageClass: params.storage_class || 'STANDARD',

--- a/packages/storage-mcp/src/utility/api_client_factory.ts
+++ b/packages/storage-mcp/src/utility/api_client_factory.ts
@@ -18,6 +18,7 @@ import { BigQuery } from '@google-cloud/bigquery';
 import { Storage } from '@google-cloud/storage';
 import { ServiceUsageClient } from '@google-cloud/service-usage';
 import { StorageInsightsClient } from '@google-cloud/storageinsights';
+import { USER_AGENT } from './user_agent.js';
 
 export class ApiClientFactory {
   private static instance: ApiClientFactory;
@@ -37,7 +38,7 @@ export class ApiClientFactory {
 
   getStorageClient(): Storage {
     if (!this.storageClient) {
-      this.storageClient = new Storage();
+      this.storageClient = new Storage({ userAgent: USER_AGENT });
     }
     return this.storageClient;
   }

--- a/packages/storage-mcp/src/utility/user_agent.ts
+++ b/packages/storage-mcp/src/utility/user_agent.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import pkg from '../../package.json' with { type: 'json' };
+
+export const USER_AGENT = `gcloud-storage-mcp/${pkg.version}`;


### PR DESCRIPTION
## Summary

- Adds a `user_agent.ts` utility module that defines `USER_AGENT` as `gcloud-storage-mcp/<version>`, reading the version from `package.json` in one place
- Passes `userAgent: USER_AGENT` to all `Storage` client instantiations (`ApiClientFactory.getStorageClient()` and the ad-hoc client in `create_bucket.ts`)

After this change, user will see cloud audit log like this:

```
callerSuppliedUserAgent: "gcloud-storage-mcp/0.4.0 gcloud-node-storage/7.19.0,gzip(gfe)"
```