### PR TITLE
fix(storage-mcp): use project instead of userProject in list_buckets

### DIFF
--- a/packages/storage-mcp/src/tools/buckets/list_buckets.test.ts
+++ b/packages/storage-mcp/src/tools/buckets/list_buckets.test.ts
@@ -37,7 +37,7 @@ describe('listBuckets', () => {
 
     expect(apiClientFactory.getStorageClient).toHaveBeenCalled();
     expect(mockGetBuckets).toHaveBeenCalledWith({
-      userProject: 'test-project',
+      project: 'test-project',
     });
     expect(result.content).toEqual([{ type: 'text', text: 'bucket-1\nbucket-2' }]);
   });

--- a/packages/storage-mcp/src/tools/buckets/list_buckets.ts
+++ b/packages/storage-mcp/src/tools/buckets/list_buckets.ts
@@ -33,7 +33,7 @@ export async function listBuckets(params: ListBucketsParams): Promise<CallToolRe
       'Project ID not specified. Please specify via the project_id parameter or GOOGLE_CLOUD_PROJECT environment variable.',
     );
   }
-  const [buckets] = await storage.getBuckets({ userProject: projectId });
+  const [buckets] = await storage.getBuckets({ project: projectId });
 
   if (!buckets || buckets.length === 0) {
     return { content: [{ type: 'text', text: 'No buckets found.' }] };


### PR DESCRIPTION
## Summary

- Fixes `list_buckets` to pass `project` (not `userProject`) when calling `storage.getBuckets()`
- `userProject` is for requester-pays billing attribution; `project` is the correct parameter for specifying which project's buckets to list
- Updates the corresponding unit test to assert the correct parameter is passed

See 

* https://github.com/googleapis/google-cloud-node/blob/18a3b05b079cbb614bf5c5b2aa6a92fd93e8beb1/handwritten/storage/src/storage.ts#L182-L193
* https://docs.cloud.google.com/storage/docs/json_api/v1/buckets/list#parameters
* https://docs.cloud.google.com/storage/docs/using-requester-pays#storage-download-file-requester-pays-nodejs
