### PR TITLE
fix(storage-mcp): move delete_object from safe to destructive tools

### DIFF
--- a/packages/storage-mcp/src/tools/index.ts
+++ b/packages/storage-mcp/src/tools/index.ts
@@ -57,7 +57,6 @@ export const commonSafeTools = [
   registerReadObjectContentTool,
   registerReadObjectMetadataTool,
   registerDownloadObjectSafeTool,
-  registerDeleteObjectTool,
   registerGetMetadataTableSchemaTool,
   registerExecuteInsightsQueryTool,
   registerListInsightsConfigsTool,
@@ -78,6 +77,7 @@ export const destructiveWriteTools = [
 export const otherDestructiveTools = [
   registerDeleteBucketTool,
   registerUpdateBucketLabelsTool,
+  registerDeleteObjectTool,
   registerMoveObjectTool,
   registerUpdateObjectMetadataTool,
   registerDownloadObjectTool,


### PR DESCRIPTION
## Summary

- `delete_object` was incorrectly placed in `commonSafeTools`, meaning it was always enabled even without `--enable-destructive-tools`
- Moved it to `otherDestructiveTools` so it requires the destructive flag, matching the existing README documentation which already correctly listed it as destructive
