### PR TITLE
Deny local credential-printing gcloud commands by default

### DIFF
--- a/packages/gcloud-mcp/src/index.test.ts
+++ b/packages/gcloud-mcp/src/index.test.ts
@@ -102,6 +102,22 @@ test('should start the McpServer if gcloud is available', async () => {
   expect(serverInstance?.connect).toHaveBeenCalledWith(expect.any(StdioServerTransport));
 });
 
+test('default denylist includes local credential-printing commands', async () => {
+  process.argv = ['node', 'index.js'];
+  vi.stubGlobal('process', { ...process, exit: vi.fn(), on: vi.fn() });
+
+  const { default_deny } = await import('./index.js');
+
+  expect(default_deny).toEqual(
+    expect.arrayContaining([
+      'auth print-access-token',
+      'auth print-identity-token',
+      'auth application-default print-access-token',
+      'config config-helper',
+    ]),
+  );
+});
+
 test('should exit if load deny and allow from config file', async () => {
   process.argv = ['node', 'index.js', '--config', 'test-config.json'];
   const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/gcloud-mcp/src/index.ts
+++ b/packages/gcloud-mcp/src/index.ts
@@ -38,6 +38,10 @@ export const default_deny: string[] = [
   'cloud-shell ssh',
   'workstations ssh',
   'app instances ssh',
+  'auth print-access-token',
+  'auth print-identity-token',
+  'auth application-default print-access-token',
+  'config config-helper',
   'interactive',
   'meta',
 ];

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
@@ -117,6 +117,19 @@ describe('createRunGcloudCommand', () => {
       expect(result.isError).toBe(true);
     });
 
+    test('does not return stdout for denylisted credential-printing commands', async () => {
+      const tool = createTool({ deny: ['auth print-access-token'] });
+      const inputArgs = ['auth', 'print-access-token'];
+      mockGcloudInvoke('FAKE_ACCESS_TOKEN_SHOULD_NOT_BE_RETURNED');
+
+      const result = await tool({ args: inputArgs });
+
+      expect(mockedGcloud.invoke).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('Execution denied:');
+      expect(result.content[0].text).not.toContain('FAKE_ACCESS_TOKEN_SHOULD_NOT_BE_RETURNED');
+      expect(result.isError).toBe(true);
+    });
+
     test('invokes gcloud for non-denylisted command', async () => {
       const tool = createTool({ deny: ['compute list'] });
       const inputArgs = ['compute', 'create'];


### PR DESCRIPTION
# Title

Deny local credential-printing gcloud commands by default

# Body

This change adds local credential extraction commands to the default denylist used by `gcloud-mcp`.

The MCP tool returns stdout from allowed `gcloud` commands to the client/model. Commands such as `auth print-access-token`, `auth application-default print-access-token`, `auth print-identity-token`, and `config config-helper` can directly print transferable local credential material, so they should be denied by default in the same way that SSH, `interactive`, and `meta` command groups are denied by default.

The patch also adds regression coverage that:

- verifies the default denylist contains the credential-printing commands;
- verifies a denylisted credential-printing command does not invoke `gcloud`;
- verifies fake token stdout is not returned when the command is denied.

Tests run:

```text
npx vitest run src/index.test.ts src/tools/run_gcloud_command.test.ts src/denylist.test.ts --reporter=verbose --coverage=false
npm run build
npx prettier --check src/index.ts src/index.test.ts src/tools/run_gcloud_command.test.ts
npx eslint src/index.ts src/index.test.ts src/tools/run_gcloud_command.test.ts --max-warnings 0
```
