### PR TITLE
Fix: Fix integration testing

### DIFF
--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -1,11 +1,12 @@
 substitutions:
-  _GEMINI_CLI_RELEASE_VERSION: '0.38.2'
+  _GEMINI_CLI_RELEASE_VERSION: 'latest'
 steps:
   - name: 'node:20'
     env:
       - 'GOOGLE_GENAI_USE_VERTEXAI=true'
       - 'GOOGLE_CLOUD_PROJECT=gcloud-mcp-testing'
       - 'GOOGLE_CLOUD_LOCATION=us-central1'
+      - 'GEMINI_CLI_TRUST_WORKSPACE=true'
     entrypoint: 'bash'
     args:
       - '-c'

--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -41,6 +41,7 @@ steps:
         npx gcloud-mcp init --agent=gemini-cli --local
         npx observability-mcp init --agent=gemini-cli --local
         npx storage-mcp init --agent=gemini-cli --local
+        cat /builder/home/.gemini/extensions/storage-mcp/gemini-extension.json
 
         echo "--- Installing Go ---"
         GO_VERSION="1.23.0"

--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  _GEMINI_CLI_RELEASE_VERSION: 'latest'
+  _GEMINI_CLI_RELEASE_VERSION: '0.38.2'
 steps:
   - name: 'node:20'
     env:

--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -42,6 +42,8 @@ steps:
         npx observability-mcp init --agent=gemini-cli --local
         npx storage-mcp init --agent=gemini-cli --local
         cat /builder/home/.gemini/extensions/storage-mcp/gemini-extension.json
+        cat /builder/home/.gemini/extensions/observability-mcp/gemini-extension.json
+        cat /builder/home/.gemini/extensions/gcloud-mcp/gemini-extension.json
 
         echo "--- Installing Go ---"
         GO_VERSION="1.23.0"

--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -44,6 +44,9 @@ steps:
         cat /builder/home/.gemini/extensions/storage-mcp/gemini-extension.json
         cat /builder/home/.gemini/extensions/observability-mcp/gemini-extension.json
         cat /builder/home/.gemini/extensions/gcloud-mcp/gemini-extension.json
+        npx -y gcloud-mcp
+        npx -y storage-mcp
+        npx -y observability-mcp
 
         echo "--- Installing Go ---"
         GO_VERSION="1.23.0"

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -13,7 +13,7 @@ import (
 func testGeminiMcpList() error {
 	fmt.Println("🚀 Starting gcloud-mcp integration test...")
 
-	cmd := exec.Command("gemini", "mcp", "list")
+	cmd := exec.Command("gemini", "--debug", "mcp", "list")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error executing command: %v\nOutput:\n%s", err, string(output))

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -97,10 +97,10 @@ func testCallGcloudMCPTool() error {
 }
 
 func run() int {
-	if err := testGeminiMcpList(); err != nil {
-		fmt.Printf("❌ %v\n", err)
-		return 1
-	}
+	// if err := testGeminiMcpList(); err != nil {
+	// 	fmt.Printf("❌ %v\n", err)
+	// 	return 1
+	// }
 	if err := testCallGcloudMCPTool(); err != nil {
 		fmt.Printf("❌ %v\n", err)
 		return 1

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -13,7 +13,7 @@ import (
 func testGeminiMcpList() error {
 	fmt.Println("🚀 Starting gcloud-mcp integration test...")
 
-	cmd := exec.Command("gemini", "--debug", "mcp", "list")
+	cmd := exec.Command("gemini", "mcp", "list")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error executing command: %v\nOutput:\n%s", err, string(output))

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -97,10 +97,10 @@ func testCallGcloudMCPTool() error {
 }
 
 func run() int {
-	// if err := testGeminiMcpList(); err != nil {
-	// 	fmt.Printf("❌ %v\n", err)
-	// 	return 1
-	// }
+	if err := testGeminiMcpList(); err != nil {
+		fmt.Printf("❌ %v\n", err)
+		return 1
+	}
 	if err := testCallGcloudMCPTool(); err != nil {
 		fmt.Printf("❌ %v\n", err)
 		return 1


### PR DESCRIPTION
Integration tests were failing to match gemini mcp list outputs. This failure is caused by a new security feature rolled out in Gemini CLI where when it is run in headless mode, it do not connect to MCP servers. 