### PR TITLE
Fix: Integration tests failing due to MCP not connecting

### DIFF
--- a/tests/cloudbuild.yaml
+++ b/tests/cloudbuild.yaml
@@ -1,11 +1,12 @@
 substitutions:
-  _GEMINI_CLI_RELEASE_VERSION: '0.38.2'
+  _GEMINI_CLI_RELEASE_VERSION: 'latest'
 steps:
   - name: 'node:20'
     env:
       - 'GOOGLE_GENAI_USE_VERTEXAI=true'
       - 'GOOGLE_CLOUD_PROJECT=gcloud-mcp-testing'
       - 'GOOGLE_CLOUD_LOCATION=us-central1'
+      - 'GEMINI_CLI_TRUST_WORKSPACE=true'
     entrypoint: 'bash'
     args:
       - '-c'


### PR DESCRIPTION
Root Cause
The Issue: Local MCP servers (like gcloud-mcp-local) were showing as Disconnected during integration tests in Cloud Build when using newer versions of the Gemini CLI (v0.40.0+).
Why it happens: Gemini CLI introduced a "Trusted Folders" security feature. In headless/CI environments, the workspace defaults to "Untrusted" (Safe Mode) which automatically blocks the execution and startup of local MCP servers.

The Fix
Explicitly trust the workspace in Cloud Build by adding GEMINI_CLI_TRUST_WORKSPACE=true to the environment variables in cloudbuild.yaml.