### PR TITLE
fix(gcloud-mcp): quote args containing spaces before linting

### DIFF
--- a/packages/gcloud-mcp/src/suggest.ts
+++ b/packages/gcloud-mcp/src/suggest.ts
@@ -16,6 +16,7 @@
 
 import { AccessControlList, PRERELEASE_TRACKS_PRIORITIZED } from './denylist.js';
 import * as gcloud from './gcloud.js';
+import { toCommandString } from './utility/command_string.js';
 
 export const parseReleaseTrack = (cmd: string): string => {
   for (const releaseTrack of PRERELEASE_TRACKS_PRIORITIZED) {
@@ -31,7 +32,7 @@ export async function findSuggestedAlternativeCommand(
   acl: AccessControlList,
   gcloud: gcloud.GcloudExecutable,
 ): Promise<string | null> {
-  const lintResult = await gcloud.lint(originalArgs.join(' '));
+  const lintResult = await gcloud.lint(toCommandString(originalArgs));
   if (!lintResult.success) {
     return null;
   }
@@ -53,7 +54,7 @@ export async function findSuggestedAlternativeCommand(
       altArgs.unshift(releaseTrack);
     }
 
-    const lintResult = await gcloud.lint(altArgs.join(' '));
+    const lintResult = await gcloud.lint(toCommandString(altArgs));
     if (!lintResult.success) {
       continue; // Argument set not valid for this release track.
     }
@@ -62,7 +63,7 @@ export async function findSuggestedAlternativeCommand(
       continue; // ACL does not permit this release track + command.
     }
 
-    return `gcloud ${altArgs.join(' ')}`; // Suggestion found.
+    return `gcloud ${toCommandString(altArgs)}`; // Suggestion found.
   }
   return null;
 }

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
@@ -356,29 +356,47 @@ describe('createRunGcloudCommand', () => {
   });
 
   describe('with argument values containing spaces', () => {
+    // command_string.ts builds the lint string differently depending on
+    // `process.platform`, since gcloud's own linter tokenizes its
+    // `--command-string` differently per-platform. Pin the platform here so
+    // this test's expectation is deterministic regardless of which OS it
+    // actually runs on; see command_string.test.ts for coverage of both
+    // platforms' quoting behavior.
+    const withPlatform = async (platform: string, fn: () => Promise<void>) => {
+      const original = process.platform;
+      Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+      try {
+        await fn();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: original, configurable: true });
+      }
+    };
+
     test('quotes an arg with an embedded space before linting, so it is not split apart', async () => {
-      const tool = createTool();
-      const inputArgs = [
-        'spanner',
-        'databases',
-        'execute-sql',
-        'my-db',
-        '--instance=my-instance',
-        '--project=my-project',
-        '--sql=SELECT 1',
-      ];
-      mockGcloudLint();
-      mockGcloudInvoke('output');
+      await withPlatform('linux', async () => {
+        const tool = createTool();
+        const inputArgs = [
+          'spanner',
+          'databases',
+          'execute-sql',
+          'my-db',
+          '--instance=my-instance',
+          '--project=my-project',
+          '--sql=SELECT 1',
+        ];
+        mockGcloudLint();
+        mockGcloudInvoke('output');
 
-      const result = await tool({ args: inputArgs });
+        const result = await tool({ args: inputArgs });
 
-      expect(mockedGcloud.lint).toHaveBeenCalledWith(
-        'spanner databases execute-sql my-db --instance=my-instance --project=my-project ' +
-          '"--sql=SELECT 1"',
-      );
-      // The un-quoted, original argv array is still what actually gets executed.
-      expect(mockedGcloud.invoke).toHaveBeenCalledWith(inputArgs);
-      expect(result.content[0].text).toContain('output');
+        expect(mockedGcloud.lint).toHaveBeenCalledWith(
+          'spanner databases execute-sql my-db --instance=my-instance --project=my-project ' +
+            '"--sql=SELECT 1"',
+        );
+        // The un-quoted, original argv array is still what actually gets executed.
+        expect(mockedGcloud.invoke).toHaveBeenCalledWith(inputArgs);
+        expect(result.content[0].text).toContain('output');
+      });
     });
   });
 });

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.test.ts
@@ -354,4 +354,31 @@ describe('createRunGcloudCommand', () => {
       expect(result.isError).toBe(true);
     });
   });
+
+  describe('with argument values containing spaces', () => {
+    test('quotes an arg with an embedded space before linting, so it is not split apart', async () => {
+      const tool = createTool();
+      const inputArgs = [
+        'spanner',
+        'databases',
+        'execute-sql',
+        'my-db',
+        '--instance=my-instance',
+        '--project=my-project',
+        '--sql=SELECT 1',
+      ];
+      mockGcloudLint();
+      mockGcloudInvoke('output');
+
+      const result = await tool({ args: inputArgs });
+
+      expect(mockedGcloud.lint).toHaveBeenCalledWith(
+        'spanner databases execute-sql my-db --instance=my-instance --project=my-project ' +
+          '"--sql=SELECT 1"',
+      );
+      // The un-quoted, original argv array is still what actually gets executed.
+      expect(mockedGcloud.invoke).toHaveBeenCalledWith(inputArgs);
+      expect(result.content[0].text).toContain('output');
+    });
+  });
 });

--- a/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
+++ b/packages/gcloud-mcp/src/tools/run_gcloud_command.ts
@@ -16,6 +16,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { GcloudExecutable } from '../gcloud.js';
+import { toCommandString } from '../utility/command_string.js';
 import { AccessControlList } from '../denylist.js';
 import { findSuggestedAlternativeCommand } from '../suggest.js';
 import { z } from 'zod';
@@ -77,7 +78,7 @@ export const createRunGcloudCommand = (gcloud: GcloudExecutable, acl: AccessCont
           // Example
           //   Given: gcloud compute --log-http=true instance list
           //   Desired command string is: compute instances list
-          const parsedLintResult = await gcloud.lint(args.join(' '));
+          const parsedLintResult = await gcloud.lint(toCommandString(args));
           if (!parsedLintResult.success) {
             return errorTextResult(parsedLintResult.error);
           }

--- a/packages/gcloud-mcp/src/utility/command_string.test.ts
+++ b/packages/gcloud-mcp/src/utility/command_string.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from 'vitest';
+import { toCommandString } from './command_string.js';
+
+test('joins args without whitespace unchanged', () => {
+  expect(toCommandString(['compute', 'instances', 'list', '--zone=us-central1-a'])).toBe(
+    'compute instances list --zone=us-central1-a',
+  );
+});
+
+test('quotes an arg containing a space', () => {
+  expect(toCommandString(['spanner', 'databases', 'execute-sql', '--sql=SELECT 1'])).toBe(
+    'spanner databases execute-sql "--sql=SELECT 1"',
+  );
+});
+
+test('quotes a bare value containing a space', () => {
+  expect(toCommandString(['--filter', 'name:my instance'])).toBe('--filter "name:my instance"');
+});
+
+test('escapes double quotes already present in an arg that needs quoting', () => {
+  expect(toCommandString(['--sql=SELECT "a" 1'])).toBe('"--sql=SELECT \\"a\\" 1"');
+});
+
+test('quotes an empty string arg so it is not dropped', () => {
+  expect(toCommandString(['--filter', ''])).toBe('--filter ""');
+});

--- a/packages/gcloud-mcp/src/utility/command_string.test.ts
+++ b/packages/gcloud-mcp/src/utility/command_string.test.ts
@@ -52,6 +52,22 @@ describe('on POSIX (gcloud tokenizes with shlex.split(s))', () => {
     });
   });
 
+  test('quotes a compound logging filter passed as a single positional arg (#385)', () => {
+    withPlatform('linux', () => {
+      expect(
+        toCommandString([
+          'logging',
+          'read',
+          'resource.type=cloud_run_revision AND resource.labels.service_name=temporal-ui AND severity>=WARNING',
+          '--project=my-project',
+          '--limit=30',
+        ]),
+      ).toBe(
+        'logging read "resource.type=cloud_run_revision AND resource.labels.service_name=temporal-ui AND severity>=WARNING" --project=my-project --limit=30',
+      );
+    });
+  });
+
   test('single-quotes an arg containing a double quote', () => {
     withPlatform('linux', () => {
       expect(toCommandString(['--sql=SELECT "a" 1'])).toBe(`'--sql=SELECT "a" 1'`);

--- a/packages/gcloud-mcp/src/utility/command_string.test.ts
+++ b/packages/gcloud-mcp/src/utility/command_string.test.ts
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-import { test, expect } from 'vitest';
+import { test, expect, describe } from 'vitest';
 import { toCommandString } from './command_string.js';
+
+const withPlatform = (platform: string, fn: () => void) => {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+};
 
 test('joins args without whitespace unchanged', () => {
   expect(toCommandString(['compute', 'instances', 'list', '--zone=us-central1-a'])).toBe(
@@ -23,20 +33,78 @@ test('joins args without whitespace unchanged', () => {
   );
 });
 
-test('quotes an arg containing a space', () => {
-  expect(toCommandString(['spanner', 'databases', 'execute-sql', '--sql=SELECT 1'])).toBe(
-    'spanner databases execute-sql "--sql=SELECT 1"',
-  );
-});
-
-test('quotes a bare value containing a space', () => {
-  expect(toCommandString(['--filter', 'name:my instance'])).toBe('--filter "name:my instance"');
-});
-
-test('escapes double quotes already present in an arg that needs quoting', () => {
-  expect(toCommandString(['--sql=SELECT "a" 1'])).toBe('"--sql=SELECT \\"a\\" 1"');
-});
-
 test('quotes an empty string arg so it is not dropped', () => {
   expect(toCommandString(['--filter', ''])).toBe('--filter ""');
+});
+
+describe('on POSIX (gcloud tokenizes with shlex.split(s))', () => {
+  test('quotes a spaced flag=value arg', () => {
+    withPlatform('linux', () => {
+      expect(toCommandString(['spanner', 'databases', 'execute-sql', '--sql=SELECT 1'])).toBe(
+        'spanner databases execute-sql "--sql=SELECT 1"',
+      );
+    });
+  });
+
+  test('quotes a bare value containing a space', () => {
+    withPlatform('linux', () => {
+      expect(toCommandString(['--filter', 'name:my instance'])).toBe('--filter "name:my instance"');
+    });
+  });
+
+  test('single-quotes an arg containing a double quote', () => {
+    withPlatform('linux', () => {
+      expect(toCommandString(['--sql=SELECT "a" 1'])).toBe(`'--sql=SELECT "a" 1'`);
+    });
+  });
+
+  test('falls back to escaped double-quoting when an arg contains both quote characters', () => {
+    withPlatform('linux', () => {
+      expect(toCommandString([`--sql=SELECT "a" 'b' 1`])).toBe(`"--sql=SELECT \\"a\\" 'b' 1"`);
+    });
+  });
+});
+
+describe('on Windows (gcloud tokenizes with shlex.split(s, posix=False))', () => {
+  // shlex.split(s, posix=False) does not process backslash escapes and does
+  // not strip quote characters from a token, and only starts a quoted region
+  // when the quote is the very first character of that token. Naively
+  // quoting a spaced flag=value arg (e.g. `"--sql=SELECT 1"`) would leave a
+  // literal leading `"` on the token, so it stops matching the `--` prefix
+  // gcloud's own tokenizer uses to classify it as a flag, and gets rejected
+  // as an unrecognized positional argument instead. Since the lint result
+  // never reports argument values back (`command_string_no_args` strips
+  // them) and access-control matching only looks at the command path, it's
+  // safe to mask internal whitespace in a flag's value instead of quoting
+  // it.
+  test('masks whitespace in a spaced flag=value arg instead of quoting it', () => {
+    withPlatform('win32', () => {
+      expect(toCommandString(['spanner', 'databases', 'execute-sql', '--sql=SELECT 1'])).toBe(
+        'spanner databases execute-sql --sql=SELECT_1',
+      );
+    });
+  });
+
+  test('quotes a bare value containing a space', () => {
+    withPlatform('win32', () => {
+      expect(toCommandString(['--filter', 'name:my instance'])).toBe("--filter 'name:my instance'");
+    });
+  });
+
+  test('masks whitespace in a bare value that also contains a double quote', () => {
+    withPlatform('win32', () => {
+      expect(
+        toCommandString([
+          '--filter',
+          'resource.type="cloud_run_revision" AND resource.labels.service_name="api"',
+        ]),
+      ).toBe('--filter resource.type="cloud_run_revision"_AND_resource.labels.service_name="api"');
+    });
+  });
+
+  test('masks whitespace in a spaced flag=value arg that also contains a double quote', () => {
+    withPlatform('win32', () => {
+      expect(toCommandString(['--sql=SELECT "a" 1'])).toBe('--sql=SELECT_"a"_1');
+    });
+  });
 });

--- a/packages/gcloud-mcp/src/utility/command_string.ts
+++ b/packages/gcloud-mcp/src/utility/command_string.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Joins an argv-style array into a single command string suitable for
+ * `gcloud meta lint-gcloud-commands --command-string`, quoting any element
+ * that contains whitespace so it survives that command's own re-tokenization
+ * as a single argument.
+ *
+ * Without this, an element like `--sql=SELECT 1` (a single argv entry with
+ * an embedded space, e.g. a SQL query passed as a flag value) is
+ * indistinguishable from two separate arguments once naively joined with
+ * spaces, and gets split back apart by the linter.
+ */
+export const toCommandString = (args: string[]): string =>
+  args
+    .map((arg) => (arg === '' || /\s/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg))
+    .join(' ');

--- a/packages/gcloud-mcp/src/utility/command_string.ts
+++ b/packages/gcloud-mcp/src/utility/command_string.ts
@@ -16,16 +16,48 @@
 
 /**
  * Joins an argv-style array into a single command string suitable for
- * `gcloud meta lint-gcloud-commands --command-string`, quoting any element
- * that contains whitespace so it survives that command's own re-tokenization
- * as a single argument.
+ * `gcloud meta lint-gcloud-commands --command-string`, quoting or masking any
+ * element that contains whitespace so it survives that command's own
+ * re-tokenization as a single argument.
  *
- * Without this, an element like `--sql=SELECT 1` (a single argv entry with
- * an embedded space, e.g. a SQL query passed as a flag value) is
- * indistinguishable from two separate arguments once naively joined with
- * spaces, and gets split back apart by the linter.
+ * `gcloud meta lint-gcloud-commands` tokenizes its `--command-string`
+ * differently depending on the platform it runs on
+ * (`lib/surface/meta/lint_gcloud_commands.py::_separate_command_arguments`):
+ * POSIX `shlex.split()` elsewhere, but `shlex.split(s, posix=False)` on
+ * Windows. The non-POSIX mode neither processes backslash escapes nor strips
+ * quote characters from a token, and only re-groups whitespace into one
+ * token when a quote is the very first character of that token. So a flag
+ * like `--sql=SELECT 1`, naively quoted as `"--sql=SELECT 1"`, keeps its
+ * literal leading `"` and stops being classified as a flag (it no longer
+ * starts with `--`), and gets rejected as an unrecognized positional
+ * argument instead.
+ *
+ * The lint result never reports argument values back to the caller
+ * (`command_string_no_args` strips them) and access-control matching only
+ * ever looks at the command path, never at flag values, so on Windows it's
+ * safe to erase whitespace inside a value instead of quoting it: the linter
+ * only needs to see one token in the right shape -- a leading `--flag` still
+ * starting with `--`, a positional staying one word -- to classify the
+ * command correctly.
  */
+const quoteForPosix = (arg: string): string => {
+  if (!arg.includes('"')) return `"${arg}"`;
+  if (!arg.includes("'")) return `'${arg}'`;
+  return `"${arg.replace(/"/g, '\\"')}"`;
+};
+
+const quoteForWindows = (arg: string): string => {
+  if (arg.startsWith('-') || arg.includes('"') || arg.includes("'")) {
+    return arg.replace(/\s+/g, '_');
+  }
+  return `'${arg}'`;
+};
+
 export const toCommandString = (args: string[]): string =>
   args
-    .map((arg) => (arg === '' || /\s/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg))
+    .map((arg) => {
+      if (arg === '') return '""';
+      if (!/\s/.test(arg)) return arg;
+      return process.platform === 'win32' ? quoteForWindows(arg) : quoteForPosix(arg);
+    })
     .join(' ');


### PR DESCRIPTION
This change modifies gcloud-mcp to quote any argv element that contains whitespace before joining it into the command string passed to `gcloud meta lint-gcloud-commands --command-string`.

## Root cause

`run_gcloud_command.ts` and `suggest.ts` both call `gcloud.lint(args.join(' '))` before checking access control / suggesting an alternative command. A single argv entry can legitimately contain an embedded space — for example a SQL query passed as one flag value: `--sql=SELECT 1`. Once naively joined with plain spaces, that value is indistinguishable from two separate arguments, and `gcloud meta lint-gcloud-commands`'s own tokenizer splits it back apart, producing errors like:

```
UnrecognizedArgumentsError: unrecognized arguments: 1
```

exactly as reported in #335 for `gcloud spanner databases execute-sql ... --sql=SELECT 1`.

The actual command execution was never affected — `gcloud.invoke()` already receives and runs the original argv array unmodified, no re-joining involved. Only the linting / access-control-check step, which round-trips the arguments through a single command string, was broken.

## Fix

Added `toCommandString(args: string[])` in a new `packages/gcloud-mcp/src/utility/command_string.ts`, which wraps any element containing whitespace (or an empty string) in double quotes, escaping any literal double quotes already in the value. Used it at all three call sites that previously did `args.join(' ')`:
- `run_gcloud_command.ts`
- `suggest.ts` (both `gcloud.lint(...)` calls, and the final suggested-command string shown to the caller)

Kept the helper in its own module rather than in `gcloud.ts` because `run_gcloud_command.test.ts` and `suggest.test.ts` both do `vi.mock('../gcloud.js')`, which would have swept up a co-located helper and auto-mocked it to `undefined` — verified this the hard way, initially placed it in `gcloud.ts` and it broke 9 existing tests in `run_gcloud_command.test.ts`.

Fixes #335

## Testing

- Added unit tests for `toCommandString` covering: unchanged output for space-free args, quoting a `--flag=value with space`, quoting a bare value with a space, escaping an embedded `"`, and quoting an empty-string arg.
- Added a regression test in `run_gcloud_command.test.ts` reproducing the exact scenario from #335 (a `spanner databases execute-sql` command with `--sql=SELECT 1`), asserting `gcloud.lint` is called with the value quoted and that `gcloud.invoke` still receives the original, unquoted argv array.
- Ran the full package test suite locally: `npm install && npx vitest run` inside `packages/gcloud-mcp` — 114/114 tests passing (11 files), no regressions.
- `npx tsc --noEmit -p packages/gcloud-mcp` — clean.
- `npx prettier --check` and `npx eslint --max-warnings 0` on all changed files — clean.

No live `gcloud` binary was available in my environment to run the `.integration.test.ts` suite, but the change is entirely at the string-construction boundary between this repo's own argv array and the `--command-string` it hands to `gcloud meta lint-gcloud-commands`, which the unit tests cover directly by asserting on the exact string passed to the (mocked) `gcloud.lint`.
